### PR TITLE
Refactor authz strategy

### DIFF
--- a/jar-connector/src/main/resources/com/sixsq/slipstream/configuration/default.config.properties
+++ b/jar-connector/src/main/resources/com/sixsq/slipstream/configuration/default.config.properties
@@ -57,6 +57,7 @@ slipstream.quota.enable = false
 
 slipstream.service.catalog.enable = false
 
+slipstream.ring.hostname = http://localhost:6666
 
 ###############################
 ### Cloud connector section ###

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Guarded.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Guarded.java
@@ -1,0 +1,11 @@
+package com.sixsq.slipstream.persistence;
+
+public interface Guarded {
+
+	public Authz getAuthz();
+
+	public void setAuthz(Authz authz);
+
+	public Guarded getGuardedParent();
+
+}

--- a/jar-persistence/src/test/java/com/sixsq/slipstream/persistence/AuthzTest.java
+++ b/jar-persistence/src/test/java/com/sixsq/slipstream/persistence/AuthzTest.java
@@ -165,6 +165,8 @@ public class AuthzTest {
 		// reset parent group members
 		parentAuthz.setGroupMembers("");
 		parents.add(parent.store());
+		// The parent is cached in the child, so we clear it
+		((Module)moduleAuthz.getGuarded()).clearGuardedParent();
 		assertThat(moduleAuthz.canGet(user), is(false));
 
 		for(Metadata p : parents) {
@@ -191,6 +193,7 @@ public class AuthzTest {
 		Module module = new ImageModule("parent/project/module");
 		Authz moduleAuthz = new Authz(owner.getName(), module);
 		moduleAuthz.setGroupGet(true);
+		module.store();
 		
 		// group can view but user not in parent group
 		assertThat(moduleAuthz.canGet(user), is(false));
@@ -198,10 +201,13 @@ public class AuthzTest {
 		// add to parent group
 		parent.getAuthz().addGroupMember("user");
 		parent.store();
+		
+		module = Module.load(module.getResourceUri());
 
 		// now user can view
-		assertThat(moduleAuthz.canGet(user), is(true));
+		assertThat(module.getAuthz().canGet(user), is(true));
 
+		module.remove();
 		project.remove();
 		parent.remove();
 		


### PR DESCRIPTION
Removes the OneToOne relationship between module and authz entity. The Guarded interface allows any entity to be "guarded" by a authz object, which is "embedded" as new columns in the same table.

Details:
1. Embeds the authz in the same table
2. Introduces the Guarded interface
3. Requires db migration