### PR TITLE
Feature/pagination

### DIFF
--- a/jar-connector/src/test/java/com/sixsq/slipstream/run/RunTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/run/RunTest.java
@@ -299,8 +299,7 @@ public class RunTest extends RunTestBase {
 		dontfindit.store();
 		Metadata run3 = createAndStoreRun(dontfindit, RunType.Machine);
 
-		List<RunView> runList = Run.viewList(findit.getResourceUri(), new User(
-				"user"));
+		List<RunView> runList = Run.viewList(new User("user"), findit.getResourceUri());
 
 		assertEquals(2, runList.size());
 
@@ -327,8 +326,7 @@ public class RunTest extends RunTestBase {
 		Run myOtherRun = createAndStoreRun(image, RunType.Machine);
 		Run notMyRun = createAndStoreRun(image, "other", RunType.Machine);
 
-		List<RunView> runList = Run.viewList(image.getResourceUri(), new User(
-				"user"));
+		List<RunView> runList = Run.viewList(new User("user"), image.getResourceUri());
 
 		assertEquals(2, runList.size());
 

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Module.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Module.java
@@ -47,7 +47,7 @@ import org.simpleframework.xml.ElementMap;
 import com.sixsq.slipstream.exceptions.ValidationException;
 import com.sixsq.slipstream.module.ModuleVersionView;
 import com.sixsq.slipstream.module.ModuleView;
-import com.sixsq.slipstream.run.RunView.RunViewList;
+import com.sixsq.slipstream.run.RunViewList;
 import com.sixsq.slipstream.util.ModuleUriUtil;
 
 /**

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Run.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Run.java
@@ -314,20 +314,8 @@ public class Run extends Parameterized<Run, RunParameter> {
 		List<RunView> views = new ArrayList<RunView>();
 		RunView runView;
 		for (Run r : runs) {
-			// Deployment runs can span several clouds
-			// this info in held in getCloudServiceNameList()
-			// so if the list is not empty, use it and
-			// create a RunView instance for each
-			String[] cloudServiceNames = r.getCloudServiceNamesList();
-
 			runView = convertRunToRunView(r);
-
-			// For each cloud service, create a RunView entry
-			for (String csn : cloudServiceNames) {
-				RunView rv = runView.copy();
-				rv.setCloudServiceName(csn);
-				views.add(rv);
-			}
+			views.add(runView);
 		}
 		return views;
 	}
@@ -339,24 +327,20 @@ public class Run extends Parameterized<Run, RunParameter> {
 		}
 
 		RunView runView;
-		runView = new RunView(run.getResourceUri(), run.getUuid(),
-				run.getModuleResourceUrl(), run.getState().toString(),
-				run.getStart(), run.getUser(), run.getType());
+		runView = new RunView(run.getResourceUri(), run.getUuid(), run.getModuleResourceUrl(), run.getState()
+				.toString(), run.getStart(), run.getUser(), run.getType(), run.getCloudServiceNames());
 		try {
-			runView.setHostname(run
-					.getRuntimeParameterValueIgnoreAbort(MACHINE_NAME_PREFIX
-							+ RuntimeParameter.HOSTNAME_KEY));
+			runView.setHostname(run.getRuntimeParameterValueIgnoreAbort(MACHINE_NAME_PREFIX
+					+ RuntimeParameter.HOSTNAME_KEY));
 		} catch (NotFoundException e) {
 		}
 		try {
-			runView.setVmstate(run
-					.getRuntimeParameterValueIgnoreAbort(MACHINE_NAME_PREFIX
-							+ RuntimeParameter.STATE_VM_KEY));
+			runView.setVmstate(run.getRuntimeParameterValueIgnoreAbort(MACHINE_NAME_PREFIX
+					+ RuntimeParameter.STATE_VM_KEY));
 		} catch (NotFoundException e) {
 		}
 		try {
-			runView.setTags(run
-					.getRuntimeParameterValueIgnoreAbort(RuntimeParameter.GLOBAL_TAGS_KEY));
+			runView.setTags(run.getRuntimeParameterValueIgnoreAbort(RuntimeParameter.GLOBAL_TAGS_KEY));
 		} catch (NotFoundException e) {
 		}
 		return runView;
@@ -429,6 +413,7 @@ public class Run extends Parameterized<Run, RunParameter> {
 			where = andPredicate(builder, where, builder.equal(rootQuery.get("moduleResourceUri"), moduleResourceUri));
 		}
 		if (cloudServiceName != null && !"".equals(cloudServiceName)) {
+			// TODO: Replace the 'like' by an 'equals'
 			where = andPredicate(builder, where, builder.like(rootQuery.<String>get("cloudServiceNames"), "%" + cloudServiceName + "%"));
 		}
 		return where;

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Run.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Run.java
@@ -368,11 +368,11 @@ public class Run extends Parameterized<Run, RunParameter> {
 
 	public static List<RunView> viewList(User user, String moduleResourceUri)
 			throws ConfigurationException, ValidationException {
-		return viewList(user, moduleResourceUri, null, null);
+		return viewList(user, moduleResourceUri, null, null, null);
 	}
 
 	public static List<RunView> viewList(User user, String moduleResourceUri, Integer offset,
-			Integer limit) throws ConfigurationException, ValidationException {
+			Integer limit, String cloudServiceName) throws ConfigurationException, ValidationException {
 		List<RunView> views = null;
 		EntityManager em = PersistenceUtil.createEntityManager();
 		try {
@@ -380,7 +380,7 @@ public class Run extends Parameterized<Run, RunParameter> {
 			CriteriaQuery<Run> critQuery = builder.createQuery(Run.class);
 			Root<Run> rootQuery = critQuery.from(Run.class);
 			critQuery.select(rootQuery);
-			Predicate where = viewListCommonQueryOptions(builder, rootQuery, user, moduleResourceUri);
+			Predicate where = viewListCommonQueryOptions(builder, rootQuery, user, moduleResourceUri, cloudServiceName);
 			if (where != null){
 				critQuery.where(where);
 			}
@@ -398,7 +398,7 @@ public class Run extends Parameterized<Run, RunParameter> {
 		return views;
 	}
 
-	public static int viewListCount(User user, String moduleResourceUri)
+	public static int viewListCount(User user, String moduleResourceUri, String cloudServiceName)
 			throws ConfigurationException, ValidationException {
 		int count = 0;
 		EntityManager em = PersistenceUtil.createEntityManager();
@@ -407,7 +407,7 @@ public class Run extends Parameterized<Run, RunParameter> {
 			CriteriaQuery<Long> critQuery = builder.createQuery(Long.class);
 			Root<Run> rootQuery = critQuery.from(Run.class);
 			critQuery.select(builder.count(rootQuery));
-			Predicate where = viewListCommonQueryOptions(builder, rootQuery, user, moduleResourceUri);
+			Predicate where = viewListCommonQueryOptions(builder, rootQuery, user, moduleResourceUri, cloudServiceName);
 			if (where != null){
 				critQuery.where(where);
 			}
@@ -420,13 +420,16 @@ public class Run extends Parameterized<Run, RunParameter> {
 	}
 
 	private static Predicate viewListCommonQueryOptions(CriteriaBuilder builder, Root<Run> rootQuery, User user,
-			String moduleResourceUri) {
+			String moduleResourceUri, String cloudServiceName) {
 		Predicate where = null;
 		if (!user.isSuper()) {
 			where = andPredicate(builder, where, builder.equal(rootQuery.get("user_"), user.getName()));
 		}
 		if (moduleResourceUri != null && !"".equals(moduleResourceUri)) {
 			where = andPredicate(builder, where, builder.equal(rootQuery.get("moduleResourceUri"), moduleResourceUri));
+		}
+		if (cloudServiceName != null && !"".equals(cloudServiceName)) {
+			where = andPredicate(builder, where, builder.like(rootQuery.<String>get("cloudServiceNames"), "%" + cloudServiceName + "%"));
 		}
 		return where;
 	}

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Run.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Run.java
@@ -53,6 +53,11 @@ import javax.persistence.Query;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.Transient;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
 
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.annotations.CollectionType;
@@ -72,12 +77,8 @@ import com.sixsq.slipstream.statemachine.States;
 @SuppressWarnings("serial")
 @Entity(name="Run")
 @NamedQueries({
-		@NamedQuery(name = "allActiveRuns", query = "SELECT r FROM Run r WHERE r.state NOT IN (:completed) ORDER BY r.startTime DESC"),
-		@NamedQuery(name = "activeRunsByUser", query = "SELECT r FROM Run r WHERE r.state NOT IN (:completed) AND r.user_ = :user ORDER BY r.startTime DESC"),
 		@NamedQuery(name = "allRuns", query = "SELECT r FROM Run r ORDER BY r.startTime DESC"),
-		@NamedQuery(name = "runsByUser", query = "SELECT r FROM Run r WHERE r.user_ = :user ORDER BY r.startTime DESC"),
 		@NamedQuery(name = "runWithRuntimeParameters", query = "SELECT r FROM Run r JOIN FETCH r.runtimeParameters p WHERE r.uuid = :uuid"),
-		@NamedQuery(name = "runsByRefModule", query = "SELECT r FROM Run r WHERE r.user_ = :user AND r.moduleResourceUri = :referenceModule ORDER BY r.startTime DESC"),
 		@NamedQuery(name = "oldInStatesRuns", query = "SELECT r FROM Run r WHERE r.user_ = :user AND r.lastStateChangeTime < :before AND r.state IN (:states)"),
 		// FIXME: check for the cloud
 		@NamedQuery(name = "runByInstanceId", query = "SELECT r FROM Run r JOIN FETCH r.runtimeParameters p WHERE r.user_ = :user AND p.name_ = 'instanceid' AND p.value = :instanceid ORDER BY r.startTime DESC") })
@@ -85,7 +86,7 @@ public class Run extends Parameterized<Run, RunParameter> {
 
 	private static final int DEFAULT_TIMEOUT = 60; // In minutes
 
-	private static final int MAX_NO_OF_ENTRIES = 20;
+	public static final int MAX_NO_OF_ENTRIES = 20;
 	public static final String ORCHESTRATOR_CLOUD_SERVICE_SEPARATOR = "-";
 	public static final String NODE_NAME_PARAMETER_SEPARATOR = "--";
 	// Orchestrator
@@ -361,23 +362,81 @@ public class Run extends Parameterized<Run, RunParameter> {
 		return runView;
 	}
 
-	@SuppressWarnings("unchecked")
-	public static List<RunView> viewListAll() throws ConfigurationException,
-			ValidationException {
+	private static Predicate andPredicate(CriteriaBuilder builder, Predicate currentPredicate, Predicate newPredicate){
+		return (currentPredicate != null) ? builder.and(currentPredicate, newPredicate) : newPredicate;
+	}
+
+	public static List<RunView> viewList(User user, String moduleResourceUri)
+			throws ConfigurationException, ValidationException {
+		return viewList(user, moduleResourceUri, null, null);
+	}
+
+	public static List<RunView> viewList(User user, String moduleResourceUri, Integer offset,
+			Integer limit) throws ConfigurationException, ValidationException {
+		List<RunView> views = null;
 		EntityManager em = PersistenceUtil.createEntityManager();
-		Query q = createNamedQuery(em, "allRuns");
-		List<Run> runs = q.getResultList();
-		List<RunView> views = convertRunsToRunViews(runs);
-		em.close();
+		try {
+			CriteriaBuilder builder = em.getCriteriaBuilder();
+			CriteriaQuery<Run> critQuery = builder.createQuery(Run.class);
+			Root<Run> rootQuery = critQuery.from(Run.class);
+			critQuery.select(rootQuery);
+			Predicate where = viewListCommonQueryOptions(builder, rootQuery, user, moduleResourceUri);
+			if (where != null){
+				critQuery.where(where);
+			}
+			critQuery.orderBy(builder.desc(rootQuery.get("startTime")));
+			TypedQuery<Run> query = em.createQuery(critQuery);
+			if (offset != null) {
+				query.setFirstResult(offset);
+			}
+			query.setMaxResults((limit != null)? limit : MAX_NO_OF_ENTRIES);
+			List<Run> runs = query.getResultList();
+			views = convertRunsToRunViews(runs);
+		} finally {
+			em.close();
+		}
 		return views;
 	}
 
- 	@SuppressWarnings("unchecked")
+	public static int viewListCount(User user, String moduleResourceUri)
+			throws ConfigurationException, ValidationException {
+		int count = 0;
+		EntityManager em = PersistenceUtil.createEntityManager();
+		try {
+			CriteriaBuilder builder = em.getCriteriaBuilder();
+			CriteriaQuery<Long> critQuery = builder.createQuery(Long.class);
+			Root<Run> rootQuery = critQuery.from(Run.class);
+			critQuery.select(builder.count(rootQuery));
+			Predicate where = viewListCommonQueryOptions(builder, rootQuery, user, moduleResourceUri);
+			if (where != null){
+				critQuery.where(where);
+			}
+			TypedQuery<Long> query = em.createQuery(critQuery);
+			count = (int)(long) query.getSingleResult();
+		} finally {
+			em.close();
+		}
+		return count;
+	}
+
+	private static Predicate viewListCommonQueryOptions(CriteriaBuilder builder, Root<Run> rootQuery, User user,
+			String moduleResourceUri) {
+		Predicate where = null;
+		if (!user.isSuper()) {
+			where = andPredicate(builder, where, builder.equal(rootQuery.get("user_"), user.getName()));
+		}
+		if (moduleResourceUri != null && !"".equals(moduleResourceUri)) {
+			where = andPredicate(builder, where, builder.equal(rootQuery.get("moduleResourceUri"), moduleResourceUri));
+		}
+		return where;
+	}
+
 	public static List<Run> listAll()
 			throws ConfigurationException, ValidationException {
  		EntityManager em = PersistenceUtil.createEntityManager();
 		Query q = createNamedQuery(em, "allRuns");
- 		List<Run> runs = q.getResultList();
+ 		@SuppressWarnings("unchecked")
+		List<Run> runs = q.getResultList();
  		em.close();
  		return runs;
  	}
@@ -407,18 +466,6 @@ public class Run extends Parameterized<Run, RunParameter> {
 		return runs;
 	}
 
-	@SuppressWarnings("unchecked")
-	public static List<RunView> viewList(User user)
-			throws ConfigurationException, ValidationException {
-		EntityManager em = PersistenceUtil.createEntityManager();
-		Query q = createNamedQuery(em, "runsByUser");
-		q.setParameter("user", user.getName());
-		List<Run> runs = q.getResultList();
-		List<RunView> views = convertRunsToRunViews(runs);
-		em.close();
-		return views;
-	}
-
 	public static Run loadRunWithRuntimeParameters(String uuid)
 			throws ConfigurationException, ValidationException {
 		EntityManager em = PersistenceUtil.createEntityManager();
@@ -427,30 +474,6 @@ public class Run extends Parameterized<Run, RunParameter> {
 		Run run = (Run) q.getSingleResult();
 		em.close();
 		return run;
-	}
-
-	@SuppressWarnings("unchecked")
-	public static List<RunView> viewList(String moduleResourceUri, User user)
-			throws ConfigurationException, ValidationException {
-		EntityManager em = PersistenceUtil.createEntityManager();
-		Query q = createNamedQuery(em, "runsByRefModule");
-		q.setParameter("user", user.getName());
-		q.setParameter("referenceModule", moduleResourceUri);
-		List<Run> runs = q.getResultList();
-		List<RunView> views = convertRunsToRunViews(runs);
-		em.close();
-		return views;
-	}
-
-	@SuppressWarnings("unchecked")
-	public static List<Run> listAllActive(EntityManager em, User user)
-			throws ConfigurationException, ValidationException {
-		Query q = em.createNamedQuery("activeRunsByUser");
-		q.setParameter("completed", States.Done); // TODO: hack just for
-												  // now
-		q.setParameter("user", user.getName());
-		List<Run> runs = q.getResultList();
-		return runs;
 	}
 
 	private static Query createNamedQuery(EntityManager em, String query) {

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunView.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunView.java
@@ -86,22 +86,22 @@ public class RunView {
 
 	public static List<RunView> fetchListView(User user, int offset, int limit)
 			throws ConfigurationException, ValidationException {
-		return fetchListView(user, null, offset, limit);
+		return fetchListView(user, null, offset, limit, null);
 	}
 
-	public static List<RunView> fetchListView(User user, String moduleResourceUri, int offset, int limit)
-			throws ConfigurationException, ValidationException {
-		return Run.viewList(user, moduleResourceUri, offset, limit);
+	public static List<RunView> fetchListView(User user, String moduleResourceUri, int offset, int limit,
+			String cloudServiceName) throws ConfigurationException, ValidationException {
+		return Run.viewList(user, moduleResourceUri, offset, limit, cloudServiceName);
 	}
 
 	public static int fetchListViewCount(User user)
 			throws ConfigurationException, ValidationException {
-		return fetchListViewCount(user, null);
+		return fetchListViewCount(user, null, null);
 	}
 
-	public static int fetchListViewCount(User user, String moduleResourceUri)
+	public static int fetchListViewCount(User user, String moduleResourceUri, String cloudServiceName)
 			throws ConfigurationException, ValidationException {
-		return Run.viewListCount(user, moduleResourceUri);
+		return Run.viewListCount(user, moduleResourceUri, cloudServiceName);
 	}
 
 	public RunView copy() {

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunView.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunView.java
@@ -24,7 +24,6 @@ import java.util.Date;
 import java.util.List;
 
 import org.simpleframework.xml.Attribute;
-import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
 
 import com.sixsq.slipstream.exceptions.ConfigurationException;
@@ -85,23 +84,24 @@ public class RunView {
         }
 	}
 
-	public static RunViewList fetchListView(User user, boolean isSuper)
+	public static List<RunView> fetchListView(User user, int offset, int limit)
 			throws ConfigurationException, ValidationException {
-		return fetchListView(null, user, isSuper);
+		return fetchListView(user, null, offset, limit);
 	}
 
-	public static RunViewList fetchListView(String query, User user,
-			boolean isSuper) throws ConfigurationException, ValidationException {
-		List<RunView> list;
+	public static List<RunView> fetchListView(User user, String moduleResourceUri, int offset, int limit)
+			throws ConfigurationException, ValidationException {
+		return Run.viewList(user, moduleResourceUri, offset, limit);
+	}
 
-		if (isSuper) {
-			list = (query != null) ? Run.viewList(query, user) : Run
-					.viewListAll();
-		} else {
-			list = (query != null) ? Run.viewList(query, user) : Run
-					.viewList(user);
-		}
-		return new RunViewList(list);
+	public static int fetchListViewCount(User user)
+			throws ConfigurationException, ValidationException {
+		return fetchListViewCount(user, null);
+	}
+
+	public static int fetchListViewCount(User user, String moduleResourceUri)
+			throws ConfigurationException, ValidationException {
+		return Run.viewListCount(user, moduleResourceUri);
 	}
 
 	public RunView copy() {
@@ -152,26 +152,6 @@ public class RunView {
 
 	public String getTags() {
 		return tags;
-	}
-
-	@Root(name = "runs")
-	public static class RunViewList {
-
-		@ElementList(inline = true, required = false)
-		private List<RunView> list;
-
-		@SuppressWarnings("unused")
-		private RunViewList() {
-		}
-
-		public RunViewList(List<RunView> list) {
-			this.list = list;
-		}
-
-		public List<RunView> getList() {
-			return list;
-		}
-
 	}
 
 }

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunView.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunView.java
@@ -57,7 +57,7 @@ public class RunView {
 	private String hostname;
 
 	@Attribute(required = false)
-	private String cloudServiceName;
+	private String cloudServiceNames;
 
 	@Attribute(required = false)
 	private String username;
@@ -69,13 +69,14 @@ public class RunView {
 	public String tags;
 
 	public RunView(String resourceUrl, String uuid, String moduleResourceUri,
-			String status, Date startTime, String username, RunType type) {
+			String status, Date startTime, String username, RunType type, String cloudServiceNames) {
 		this.resourceUri = resourceUrl;
 		this.uuid = uuid;
 		this.moduleResourceUri = moduleResourceUri;
 		this.status = status;
 		this.username = username;
 		this.type = type;
+		this.cloudServiceNames = cloudServiceNames;
 
         if (startTime != null) {
             this.startTime = (Date) startTime.clone();
@@ -106,20 +107,19 @@ public class RunView {
 
 	public RunView copy() {
 		RunView copy = new RunView(resourceUri, uuid, moduleResourceUri,
-				status, startTime, username, type);
+				status, startTime, username, type, cloudServiceNames);
 		copy.setHostname(hostname);
 		copy.setTags(tags);
 		copy.setVmstate(vmstate);
-		copy.setCloudServiceName(cloudServiceName);
 		return copy;
 	}
 
-	public String getCloudServiceName() {
-		return cloudServiceName;
+	public String getCloudServiceNames() {
+		return cloudServiceNames;
 	}
 
-	public void setCloudServiceName(String cloudServiceName) {
-		this.cloudServiceName = cloudServiceName;
+	public void setCloudServiceNames(String cloudServiceNames) {
+		this.cloudServiceNames = cloudServiceNames;
 	}
 
 	public String getUsername() {

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunViewList.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunViewList.java
@@ -44,6 +44,9 @@ public class RunViewList {
 	@Attribute(required=false)
 	private int count;
 
+	@Attribute(required=false)
+	private String cloud;
+
 	@ElementList(inline = true, required = false)
 	private List<RunView> runs;
 
@@ -72,6 +75,7 @@ public class RunViewList {
 			throws ConfigurationException, ValidationException {
 		this.offset = offset;
 		this.limit = limit;
+		this.cloud = cloudServiceName;
 
 		count = RunView.fetchListViewCount(user, moduleResourceUri, cloudServiceName);
 		runs = RunView.fetchListView(user, moduleResourceUri, offset, limit, cloudServiceName);

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunViewList.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunViewList.java
@@ -20,39 +20,57 @@ package com.sixsq.slipstream.run;
  * -=================================================================-
  */
 
-import org.simpleframework.xml.Element;
+import java.util.List;
+
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
 
 import com.sixsq.slipstream.exceptions.ConfigurationException;
-import com.sixsq.slipstream.exceptions.SlipStreamException;
 import com.sixsq.slipstream.exceptions.ValidationException;
 import com.sixsq.slipstream.persistence.User;
-import com.sixsq.slipstream.run.RunView.RunViewList;
+import com.sixsq.slipstream.run.RunView;
 
-@Root
-public class Runs {
 
-	@Element(required=false)
-	private RunViewList runs;
+@Root(name = "runs")
+public class RunViewList {
 
-	public RunViewList getRuns() {
+	@Attribute(required=false)
+	private int offset;
+
+	@Attribute(required=false)
+	private int limit;
+
+	@Attribute(required=false)
+	private int count;
+
+	@ElementList(inline = true, required = false)
+	private List<RunView> runs;
+
+	public RunViewList() {
+	}
+
+	public List<RunView> getRuns() {
 		return runs;
 	}
 
-	public void populate(User user) throws SlipStreamException {
-		user.validate();
-		populateRuns(user, user.isSuper());
+	public void populate(User user, int offset, int limit) throws ConfigurationException, ValidationException {
+		populate(user, null, offset, limit);
 	}
 
-	public void populateRuns(User user, boolean isSuper)
+	public void populate(User user, String moduleResourceUri, int offset, int limit)
 			throws ConfigurationException, ValidationException {
-		runs = RunView.fetchListView(user, isSuper);
+		user.validate();
+		populateRuns(user, moduleResourceUri, offset, limit);
 	}
 
-	public void populateRuns(User user, boolean isSuper,
-			String moduleResourceUri) throws ConfigurationException,
-			ValidationException {
-		runs = RunView.fetchListView(moduleResourceUri, user, isSuper);
+	private void populateRuns(User user, String moduleResourceUri, int offset, int limit)
+			throws ConfigurationException, ValidationException {
+		this.offset = offset;
+		this.limit = limit;
+
+		count = RunView.fetchListViewCount(user, moduleResourceUri);
+		runs = RunView.fetchListView(user, moduleResourceUri, offset, limit);
 	}
 
 }

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunViewList.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunViewList.java
@@ -54,23 +54,27 @@ public class RunViewList {
 		return runs;
 	}
 
-	public void populate(User user, int offset, int limit) throws ConfigurationException, ValidationException {
-		populate(user, null, offset, limit);
+	public void populate(User user, int offset, int limit, String cloudServiceName) throws ConfigurationException, ValidationException {
+		populate(user, null, offset, limit, cloudServiceName);
 	}
 
-	public void populate(User user, String moduleResourceUri, int offset, int limit)
+	public void populate(User user, String moduleResourceUri, int offset, int limit) throws ConfigurationException, ValidationException {
+		populate(user, moduleResourceUri, offset, limit, null);
+	}
+
+	public void populate(User user, String moduleResourceUri, int offset, int limit, String cloudServiceName)
 			throws ConfigurationException, ValidationException {
 		user.validate();
-		populateRuns(user, moduleResourceUri, offset, limit);
+		populateRuns(user, moduleResourceUri, offset, limit, cloudServiceName);
 	}
 
-	private void populateRuns(User user, String moduleResourceUri, int offset, int limit)
+	private void populateRuns(User user, String moduleResourceUri, int offset, int limit, String cloudServiceName)
 			throws ConfigurationException, ValidationException {
 		this.offset = offset;
 		this.limit = limit;
 
-		count = RunView.fetchListViewCount(user, moduleResourceUri);
-		runs = RunView.fetchListView(user, moduleResourceUri, offset, limit);
+		count = RunView.fetchListViewCount(user, moduleResourceUri, cloudServiceName);
+		runs = RunView.fetchListView(user, moduleResourceUri, offset, limit, cloudServiceName);
 	}
 
 }

--- a/jar-service/src/main/java/com/sixsq/slipstream/application/CommonStatusService.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/application/CommonStatusService.java
@@ -49,7 +49,6 @@ import com.sixsq.slipstream.exceptions.ValidationException;
 import com.sixsq.slipstream.persistence.ServiceConfiguration;
 import com.sixsq.slipstream.persistence.ServiceConfigurationParameter;
 import com.sixsq.slipstream.persistence.User;
-import com.sixsq.slipstream.util.ConfigurationUtil;
 import com.sixsq.slipstream.util.HtmlUtil;
 import com.sixsq.slipstream.util.ResourceUriUtil;
 import com.sixsq.slipstream.util.SerializationUtil;
@@ -58,8 +57,7 @@ import com.sixsq.slipstream.util.XmlUtil;
 public class CommonStatusService extends StatusService {
 
 	@Override
-	public Representation getRepresentation(Status status, Request request,
-			Response response) {
+	public Representation getRepresentation(Status status, Request request, Response response) {
 
 		try {
 			reloadParameters();
@@ -84,12 +82,8 @@ public class CommonStatusService extends StatusService {
 
 		String baseUrlSlash = ResourceUriUtil.getBaseUrlSlash(request);
 
-		Configuration configuration = ConfigurationUtil
-				.getConfigurationFromRequest(request);
-
 		ClientInfo clientInfo = request.getClientInfo();
-		List<Preference<MediaType>> mediaTypes = clientInfo
-				.getAcceptedMediaTypes();
+		List<Preference<MediaType>> mediaTypes = clientInfo.getAcceptedMediaTypes();
 
 		String error = statusToString(status);
 
@@ -99,13 +93,11 @@ public class CommonStatusService extends StatusService {
 
 			if (TEXT_HTML.isCompatible(desiredMediaType)) {
 
-				return toXhtml(status, response, user, baseUrlSlash,
-						configuration.version);
+				return toXhtml(status, request, response, user, baseUrlSlash);
 
 			} else if (APPLICATION_XHTML.isCompatible(desiredMediaType)) {
 
-				return toXhtml(status, response, user, baseUrlSlash,
-						configuration.version);
+				return toXhtml(status, request, response, user, baseUrlSlash);
 
 			} else if (APPLICATION_JSON.isCompatible(desiredMediaType)) {
 
@@ -125,8 +117,7 @@ public class CommonStatusService extends StatusService {
 		return representation;
 	}
 
-	private Representation toXhtml(Status status, Response response, User user,
-			String baseUrlSlash, String version) {
+	private Representation toXhtml(Status status, Request request, Response response, User user, String baseUrlSlash) {
 
 		String metadata = "";
 
@@ -136,8 +127,8 @@ public class CommonStatusService extends StatusService {
 			metadata = SerializationUtil.documentToString(doc);
 		}
 
-		return new StringRepresentation(HtmlUtil.toHtmlError(metadata,
-				status.getDescription(), status.getCode()), MediaType.TEXT_HTML);
+		return new StringRepresentation(HtmlUtil.toHtmlError(metadata, status.getDescription(), status.getCode(),
+				request), MediaType.TEXT_HTML);
 	}
 
 	private Representation toJson(Status status) {
@@ -150,8 +141,7 @@ public class CommonStatusService extends StatusService {
 		json.append("   \"detail\": \"" + status.getDescription() + "\"\n");
 		json.append("}\n");
 
-		Representation representation = new StringRepresentation(
-				json.toString());
+		Representation representation = new StringRepresentation(json.toString());
 		representation.setMediaType(APPLICATION_JSON);
 
 		return representation;
@@ -166,20 +156,16 @@ public class CommonStatusService extends StatusService {
 
 	private Representation toXml(Status status, String error) {
 		Representation representation;
-		representation = new StringRepresentation("<error code=\""
-				+ status.getCode() + "\">" + error + "</error>");
+		representation = new StringRepresentation("<error code=\"" + status.getCode() + "\">" + error + "</error>");
 		representation.setMediaType(APPLICATION_XML);
 		return representation;
 	}
 
-	private void reloadParameters() throws ConfigurationException,
-			ValidationException {
+	private void reloadParameters() throws ConfigurationException, ValidationException {
 		Configuration configuration = Configuration.getInstance();
 
-		String key = ServiceConfiguration.RequiredParameters.SLIPSTREAM_SUPPORT_EMAIL
-				.getName();
-		ServiceConfigurationParameter parameter = configuration.getParameters()
-				.getParameter(key);
+		String key = ServiceConfiguration.RequiredParameters.SLIPSTREAM_SUPPORT_EMAIL.getName();
+		ServiceConfigurationParameter parameter = configuration.getParameters().getParameter(key);
 		String email = parameter.getValue();
 
 		setContactEmail(email);
@@ -187,8 +173,7 @@ public class CommonStatusService extends StatusService {
 
 	private String statusToString(Status status) {
 
-		return "Error: " + status.getDescription() + " (" + status.getCode()
-				+ " - " + status.getReasonPhrase() + ")";
+		return "Error: " + status.getDescription() + " (" + status.getCode() + " - " + status.getReasonPhrase() + ")";
 
 	}
 }

--- a/jar-service/src/main/java/com/sixsq/slipstream/application/RootApplication.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/application/RootApplication.java
@@ -268,8 +268,7 @@ public class RootApplication extends Application {
 		guardAndAttach(router, new RunRouter(getContext()), "run");
 	}
 
-	private void attachDashboard(RootRouter router)
-			throws ConfigurationException {
+	private void attachDashboard(RootRouter router) throws ConfigurationException {
 		guardAndAttach(router, new DashboardRouter(getContext()), "dashboard");
 	}
 

--- a/jar-service/src/main/java/com/sixsq/slipstream/authn/AuthnResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/authn/AuthnResource.java
@@ -51,7 +51,7 @@ public class AuthnResource extends BaseResource {
 			metadata = SerializationUtil.documentToString(document);
 		}
 		return new StringRepresentation(HtmlUtil.toHtml(metadata, templateName,
-				null, getUser()), MediaType.TEXT_HTML);
+				getUser(), getRequest()), MediaType.TEXT_HTML);
 	}
 
 	protected Reference extractRedirectURL(Request request) {

--- a/jar-service/src/main/java/com/sixsq/slipstream/dashboard/Dashboard.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/dashboard/Dashboard.java
@@ -75,6 +75,9 @@ public class Dashboard {
 	private RunViewList runs;
 
 	@ElementList
+	private transient List<String> clouds = new ArrayList<String>();
+
+	@ElementList
 	private transient List<UsageElement> usage = new ArrayList<UsageElement>();
 
 	public void populate(User user, int offset, int limit, String cloudServiceName) throws SlipStreamException {
@@ -82,7 +85,9 @@ public class Dashboard {
 		user = User.loadByName(user.getName());  // ensure user is loaded from database
 
 		Map<String, Integer> cloudUsage = Vm.usage(user.getName());
-		for (String cloud : ConnectorFactory.getCloudServiceNamesList()) {
+		clouds = ConnectorFactory.getCloudServiceNamesList();
+
+		for (String cloud : clouds) {
 			Integer quota = Integer.parseInt(Quota.getValue(user, cloud));
 			Integer currentUsage = cloudUsage.get(cloud);
 			if (currentUsage == null) currentUsage = 0;

--- a/jar-service/src/main/java/com/sixsq/slipstream/dashboard/Dashboard.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/dashboard/Dashboard.java
@@ -25,18 +25,21 @@ import java.util.List;
 import java.util.Map;
 
 import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
 
 import com.sixsq.slipstream.connector.ConnectorFactory;
+import com.sixsq.slipstream.exceptions.ConfigurationException;
 import com.sixsq.slipstream.exceptions.SlipStreamException;
+import com.sixsq.slipstream.exceptions.ValidationException;
 import com.sixsq.slipstream.persistence.User;
 import com.sixsq.slipstream.persistence.Vm;
 import com.sixsq.slipstream.run.Quota;
-import com.sixsq.slipstream.run.Runs;
+import com.sixsq.slipstream.run.RunViewList;
 
 @Root
-public class Dashboard extends Runs {
+public class Dashboard {
 
 	public static class UsageElement {
 		@Attribute
@@ -68,11 +71,13 @@ public class Dashboard extends Runs {
         }
     }
 
+	@Element(required=false)
+	private RunViewList runs;
+
 	@ElementList
 	private transient List<UsageElement> usage = new ArrayList<UsageElement>();
 
-	public void populate(User user) throws SlipStreamException {
-		super.populate(user);
+	public void populate(User user, int offset, int limit) throws SlipStreamException {
 
 		user = User.loadByName(user.getName());  // ensure user is loaded from database
 
@@ -84,6 +89,14 @@ public class Dashboard extends Runs {
 
 			usage.add(new UsageElement(cloud, quota, currentUsage));
 		}
+
+		runs = getRuns(user, offset, limit);
+	}
+
+	private RunViewList getRuns(User user, int offset, int limit) throws ConfigurationException, ValidationException{
+		RunViewList runViewList = new RunViewList();
+		runViewList.populate(user, offset, limit);
+		return runViewList;
 	}
 
 }

--- a/jar-service/src/main/java/com/sixsq/slipstream/dashboard/Dashboard.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/dashboard/Dashboard.java
@@ -77,7 +77,7 @@ public class Dashboard {
 	@ElementList
 	private transient List<UsageElement> usage = new ArrayList<UsageElement>();
 
-	public void populate(User user, int offset, int limit) throws SlipStreamException {
+	public void populate(User user, int offset, int limit, String cloudServiceName) throws SlipStreamException {
 
 		user = User.loadByName(user.getName());  // ensure user is loaded from database
 
@@ -90,12 +90,12 @@ public class Dashboard {
 			usage.add(new UsageElement(cloud, quota, currentUsage));
 		}
 
-		runs = getRuns(user, offset, limit);
+		runs = getRuns(user, offset, limit, cloudServiceName);
 	}
 
-	private RunViewList getRuns(User user, int offset, int limit) throws ConfigurationException, ValidationException{
+	private RunViewList getRuns(User user, int offset, int limit, String cloudServiceName) throws ConfigurationException, ValidationException{
 		RunViewList runViewList = new RunViewList();
-		runViewList.populate(user, offset, limit);
+		runViewList.populate(user, offset, limit, cloudServiceName);
 		return runViewList;
 	}
 

--- a/jar-service/src/main/java/com/sixsq/slipstream/dashboard/DashboardResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/dashboard/DashboardResource.java
@@ -56,7 +56,7 @@ public class DashboardResource extends BaseResource {
 
 		before = System.currentTimeMillis();
 		String html = HtmlUtil.toHtml(dashboard,
-				getPageRepresentation(), getUser());
+				getPageRepresentation(), getUser(), getRequest());
 		logTimeDiff("html generation", before);
 
 		return new StringRepresentation(html, MediaType.TEXT_HTML);

--- a/jar-service/src/main/java/com/sixsq/slipstream/dashboard/DashboardResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/dashboard/DashboardResource.java
@@ -9,9 +9,9 @@ package com.sixsq.slipstream.dashboard;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -58,15 +58,15 @@ public class DashboardResource extends BaseResource {
 		String html = HtmlUtil.toHtml(dashboard,
 				getPageRepresentation(), getUser());
 		logTimeDiff("html generation", before);
-		
+
 		return new StringRepresentation(html, MediaType.TEXT_HTML);
 	}
 
 	private Dashboard computeDashboard() {
-	
+
 		Dashboard dashboard = new Dashboard();
 		try {
-			dashboard.populate(getUser());
+			dashboard.populate(getUser(), getOffset(), getLimit());
 		} catch (SlipStreamClientException e) {
 			throwClientConflicError(e.getMessage());
 		} catch (SlipStreamException e) {

--- a/jar-service/src/main/java/com/sixsq/slipstream/dashboard/DashboardResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/dashboard/DashboardResource.java
@@ -66,7 +66,7 @@ public class DashboardResource extends BaseResource {
 
 		Dashboard dashboard = new Dashboard();
 		try {
-			dashboard.populate(getUser(), getOffset(), getLimit());
+			dashboard.populate(getUser(), getOffset(), getLimit(), getCloud());
 		} catch (SlipStreamClientException e) {
 			throwClientConflicError(e.getMessage());
 		} catch (SlipStreamException e) {

--- a/jar-service/src/main/java/com/sixsq/slipstream/filter/ReportDecorator.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/filter/ReportDecorator.java
@@ -31,6 +31,7 @@ import org.restlet.routing.Filter;
 
 import com.sixsq.slipstream.exceptions.SlipStreamException;
 import com.sixsq.slipstream.util.HtmlUtil;
+import com.sixsq.slipstream.util.RequestUtil;
 
 public class ReportDecorator extends Filter {
 
@@ -69,7 +70,7 @@ public class ReportDecorator extends Filter {
 				.getEntityAsText());
 
 		String html = HtmlUtil.toHtml(xhtmlRepresentation,
-				getPageRepresentation());
+				getPageRepresentation(), RequestUtil.getUserFromRequest(request), request);
 
 		return new StringRepresentation(html, MediaType.TEXT_HTML);
 	}

--- a/jar-service/src/main/java/com/sixsq/slipstream/module/ModuleListResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/module/ModuleListResource.java
@@ -70,7 +70,7 @@ public class ModuleListResource extends BaseResource {
 		ModuleViewList moduleViewList = retrieveFilteredModuleViewList();
 
 		return new StringRepresentation(HtmlUtil.toHtml(moduleViewList,
-				getPageRepresentation(), getTransformationType(), getUser()),
+				getPageRepresentation(), getUser(), getRequest()),
 				MediaType.TEXT_HTML);
 	}
 

--- a/jar-service/src/main/java/com/sixsq/slipstream/module/ModuleResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/module/ModuleResource.java
@@ -65,7 +65,7 @@ import com.sixsq.slipstream.persistence.ModuleParameter;
 import com.sixsq.slipstream.persistence.ProjectModule;
 import com.sixsq.slipstream.persistence.Run;
 import com.sixsq.slipstream.resource.ParameterizedResource;
-import com.sixsq.slipstream.run.RunView.RunViewList;
+import com.sixsq.slipstream.run.RunViewList;
 import com.sixsq.slipstream.util.ModuleUriUtil;
 import com.sixsq.slipstream.util.RequestUtil;
 import com.sixsq.slipstream.util.SerializationUtil;
@@ -651,19 +651,16 @@ public class ModuleResource extends ParameterizedResource<Module> {
 	}
 
 	@Override
-	protected void addParametersForEditing() throws ValidationException,
-			ConfigurationException {
-
+	protected void addParametersForEditing() throws ValidationException, ConfigurationException {
 		ParametersFactory.addParametersForEditing(getParameterized());
 	}
 
 	@Override
-	protected Module prepareForSerialization() throws ConfigurationException,
-			ValidationException {
+	protected Module prepareForSerialization() throws ConfigurationException, ValidationException {
 		Module module = getParameterized();
 		// Add runs for this specific module version (will not apply to project)
-		RunViewList runs = new RunViewList(Run.viewList(
-				module.getResourceUri(), getUser()));
+		RunViewList runs = new RunViewList();
+		runs.populate(getUser(), module.getResourceUri(), 0, Run.MAX_NO_OF_ENTRIES);
 		module.setRuns(runs);
 		return module;
 	}

--- a/jar-service/src/main/java/com/sixsq/slipstream/module/ModuleVersionListResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/module/ModuleVersionListResource.java
@@ -91,7 +91,7 @@ public class ModuleVersionListResource extends BaseResource {
 
 		return new StringRepresentation(
 				HtmlUtil.toHtml(list,
-						getPageRepresentation(), getTransformationType(), getUser()),
+						getPageRepresentation(), getUser(), getRequest()),
 				MediaType.TEXT_HTML);
 	}
 

--- a/jar-service/src/main/java/com/sixsq/slipstream/resource/BaseResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/resource/BaseResource.java
@@ -310,4 +310,9 @@ public abstract class BaseResource extends ServerResource {
 		}
 		return limit;
 	}
+
+	protected String getCloud() {
+		Parameter cloud = getRequest().getResourceRef().getQueryAsForm().getFirst("cloud");
+		return (cloud != null)? cloud.getValue(): null;
+	}
 }

--- a/jar-service/src/main/java/com/sixsq/slipstream/resource/BaseResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/resource/BaseResource.java
@@ -27,6 +27,7 @@ import org.restlet.Request;
 import org.restlet.data.Form;
 import org.restlet.data.Cookie;
 import org.restlet.data.MediaType;
+import org.restlet.data.Parameter;
 import org.restlet.data.Reference;
 import org.restlet.data.Status;
 import org.restlet.representation.Representation;
@@ -274,5 +275,39 @@ public abstract class BaseResource extends ServerResource {
 
 	protected void logTimeDiff(String msg, long before) {
 		logTimeDiff(msg, before, System.currentTimeMillis());
+	}
+
+	protected int getOffset() {
+		Parameter offsetAttr = getRequest().getResourceRef().getQueryAsForm().getFirst("offset");
+
+		int offset = 0;
+		if (offsetAttr != null) {
+			try {
+				offset = Integer.parseInt(offsetAttr.getValue());
+			} catch (NumberFormatException e) {
+				throwClientBadRequest("Invalid format for the offset attribute");
+			}
+			if (offset < 0) {
+				throwClientBadRequest("The value for the offset attribute should be positive");
+			}
+		}
+		return offset;
+	}
+
+	protected int getLimit() {
+		Parameter limitAttr = getRequest().getResourceRef().getQueryAsForm().getFirst("limit");
+
+		int limit = 20;
+		if (limitAttr != null) {
+			try {
+				limit = Integer.parseInt(limitAttr.getValue());
+			} catch (NumberFormatException e) {
+				throwClientBadRequest("Invalid format for the limit attribute");
+			}
+			if (limit < 1 || limit > 20) {
+				throwClientBadRequest("The value for the limit attribute should be between 1 and 20");
+			}
+		}
+		return limit;
 	}
 }

--- a/jar-service/src/main/java/com/sixsq/slipstream/resource/BaseResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/resource/BaseResource.java
@@ -45,6 +45,13 @@ import com.sixsq.slipstream.util.RequestUtil;
 
 public abstract class BaseResource extends ServerResource {
 
+	public static final String PAGING_OFFSET_KEY = "offset";
+	public static final String PAGING_LIMIT_KEY = "limit";
+	public static final String PAGING_CLOUD_KEY = "cloud";
+	public static final String CHOOSER_KEY = "chooser";
+	public static final String EDIT_KEY = "edit";
+	public static final String NEW_KEY = "new";
+
 	private User user = null;
 	private ServiceConfiguration configuration = null;
 	protected static final String NEW_NAME = "new";
@@ -105,19 +112,6 @@ public abstract class BaseResource extends ServerResource {
 
 	protected User getUser() {
 		return user;
-	}
-
-	protected String getTransformationType() {
-		String type = "view";
-		if (isChooser()) {
-			type = "chooser";
-		}
-		return type;
-	}
-
-	protected boolean isChooser() {
-		String c = (String) getRequest().getAttributes().get("chooser");
-		return (c == null) ? false : true;
 	}
 
 	public ServiceConfiguration getConfiguration() {
@@ -278,7 +272,11 @@ public abstract class BaseResource extends ServerResource {
 	}
 
 	protected int getOffset() {
-		Parameter offsetAttr = getRequest().getResourceRef().getQueryAsForm().getFirst("offset");
+		return getOffset(getRequest());
+	}
+
+	public int getOffset(Request request) {
+		Parameter offsetAttr = request.getResourceRef().getQueryAsForm().getFirst(PAGING_OFFSET_KEY);
 
 		int offset = 0;
 		if (offsetAttr != null) {
@@ -295,7 +293,7 @@ public abstract class BaseResource extends ServerResource {
 	}
 
 	protected int getLimit() {
-		Parameter limitAttr = getRequest().getResourceRef().getQueryAsForm().getFirst("limit");
+		Parameter limitAttr = getRequest().getResourceRef().getQueryAsForm().getFirst(PAGING_LIMIT_KEY);
 
 		int limit = 20;
 		if (limitAttr != null) {
@@ -312,7 +310,7 @@ public abstract class BaseResource extends ServerResource {
 	}
 
 	protected String getCloud() {
-		Parameter cloud = getRequest().getResourceRef().getQueryAsForm().getFirst("cloud");
+		Parameter cloud = getRequest().getResourceRef().getQueryAsForm().getFirst(PAGING_CLOUD_KEY);
 		return (cloud != null)? cloud.getValue(): null;
 	}
 }

--- a/jar-service/src/main/java/com/sixsq/slipstream/resource/DocumentationResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/resource/DocumentationResource.java
@@ -30,7 +30,6 @@ import com.sixsq.slipstream.util.HtmlUtil;
  * -=================================================================-
  */
 
-
 public class DocumentationResource extends BaseResource {
 
 	protected String getPageRepresentation() {
@@ -49,7 +48,7 @@ public class DocumentationResource extends BaseResource {
 			metadata = user;
 		}
 
-		String html = HtmlUtil.toHtml(metadata, getPageRepresentation(), getTransformationType(), getUser());
+		String html = HtmlUtil.toHtml(metadata, getPageRepresentation(), getUser(), getRequest());
 
 		return new StringRepresentation(html, MediaType.TEXT_HTML);
 	}

--- a/jar-service/src/main/java/com/sixsq/slipstream/resource/ParameterizedResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/resource/ParameterizedResource.java
@@ -39,8 +39,7 @@ import com.sixsq.slipstream.util.RequestUtil;
 import com.sixsq.slipstream.util.ResourceUriUtil;
 import com.sixsq.slipstream.util.SerializationUtil;
 
-public abstract class ParameterizedResource<S extends Parameterized<S, ?>>
-		extends BaseResource {
+public abstract class ParameterizedResource<S extends Parameterized<S, ?>> extends BaseResource {
 
 	private S parameterized = null;
 
@@ -70,8 +69,7 @@ public abstract class ParameterizedResource<S extends Parameterized<S, ?>>
 
 	abstract protected String extractTargetUriFromRequest();
 
-	abstract protected S getOrCreateParameterized(String name)
-			throws ValidationException;
+	abstract protected S getOrCreateParameterized(String name) throws ValidationException;
 
 	public String getTargetParameterizeUri() {
 		return targetParameterizeUri;
@@ -114,8 +112,7 @@ public abstract class ParameterizedResource<S extends Parameterized<S, ?>>
 	}
 
 	protected EntityManager getEntityManager() {
-		return (EntityManager) getRequest().getAttributes().get(
-				ResourceUriUtil.ENTITY_MANAGER_KEY);
+		return (EntityManager) getRequest().getAttributes().get(ResourceUriUtil.ENTITY_MANAGER_KEY);
 	}
 
 	public S getParameterized() {
@@ -126,8 +123,7 @@ public abstract class ParameterizedResource<S extends Parameterized<S, ?>>
 
 		targetParameterizeUri = extractTargetUriFromRequest();
 
-		if (NEW_NAME.equals(ModuleUriUtil
-				.extractShortNameFromResourceUri(targetParameterizeUri))) {
+		if (NEW_NAME.equals(ModuleUriUtil.extractShortNameFromResourceUri(targetParameterizeUri))) {
 			createVolatileParameterizedForEditing();
 		} else {
 			setParameterized(loadParameterized(targetParameterizeUri));
@@ -138,19 +134,15 @@ public abstract class ParameterizedResource<S extends Parameterized<S, ?>>
 		}
 	}
 
-	abstract protected S loadParameterized(String targetParameterizedUri)
-			throws ValidationException;
+	abstract protected S loadParameterized(String targetParameterizedUri) throws ValidationException;
 
-	private void createVolatileParameterizedForEditing()
-			throws ValidationException {
-		setParameterized(getOrCreateParameterized(ModuleUriUtil
-				.extractModuleNameFromResourceUri(targetParameterizeUri)));
+	private void createVolatileParameterizedForEditing() throws ValidationException {
+		setParameterized(getOrCreateParameterized(ModuleUriUtil.extractModuleNameFromResourceUri(targetParameterizeUri)));
 		setIsEdit(true);
 	}
 
 	@Override
-	protected void setIsEdit() throws ConfigurationException,
-			ValidationException {
+	protected void setIsEdit() throws ConfigurationException, ValidationException {
 		setIsEdit(isEdit() || isEditFlagTrue() || newTemplateResource());
 	}
 
@@ -160,26 +152,21 @@ public abstract class ParameterizedResource<S extends Parameterized<S, ?>>
 
 	protected boolean newTemplateResource() {
 		return isExisting()
-				&& NEW_NAME.equals(ModuleUriUtil
-						.extractShortNameFromResourceUri(getParameterized()
-								.getName()));
+				&& NEW_NAME.equals(ModuleUriUtil.extractShortNameFromResourceUri(getParameterized().getName()));
 	}
 
 	/**
-	 * User requested the creation of a new resource. This means that
-	 * if the resource already exists, for example, creation should
-	 * be forbidden.
+	 * User requested the creation of a new resource. This means that if the
+	 * resource already exists, for example, creation should be forbidden.
 	 */
 	protected boolean xxrequestingNew() {
-		boolean newInUri = isExisting() && NEW_NAME.equals(ModuleUriUtil
-						.extractShortNameFromResourceUri(getParameterized()
-								.getName()));
+		boolean newInUri = isExisting()
+				&& NEW_NAME.equals(ModuleUriUtil.extractShortNameFromResourceUri(getParameterized().getName()));
 		boolean newInQuery = extractNewFlagFromQuery();
 		return newInQuery || newInUri;
 	}
 
-	protected void addParametersForEditing() throws ValidationException,
-			ConfigurationException {
+	protected void addParametersForEditing() throws ValidationException, ConfigurationException {
 	}
 
 	@Delete
@@ -241,14 +228,12 @@ public abstract class ParameterizedResource<S extends Parameterized<S, ?>>
 			throwConfigurationException(e);
 		}
 
-		String html = HtmlUtil.toHtml(prepared, getPageRepresentation(),
-				getTransformationType(), getUser());
+		String html = HtmlUtil.toHtml(prepared, getPageRepresentation(), getUser(), getRequest());
 
 		return new StringRepresentation(html, MediaType.TEXT_HTML);
 	}
 
-	protected S prepareForSerialization() throws ConfigurationException,
-			ValidationException {
+	protected S prepareForSerialization() throws ConfigurationException, ValidationException {
 		return getParameterized();
 	}
 
@@ -272,8 +257,7 @@ public abstract class ParameterizedResource<S extends Parameterized<S, ?>>
 
 	protected void checkCanGet() {
 		if (!canGet()) {
-			throwClientForbiddenError("Not allowed to access: "
-					+ targetParameterizeUri);
+			throwClientForbiddenError("Not allowed to access: " + targetParameterizeUri);
 		}
 	}
 
@@ -301,8 +285,7 @@ public abstract class ParameterizedResource<S extends Parameterized<S, ?>>
 	}
 
 	protected void setResponseOkAndViewLocation(String resourceUri) {
-		Status status = isExisting() ? Status.SUCCESS_OK
-				: Status.SUCCESS_CREATED;
+		Status status = isExisting() ? Status.SUCCESS_OK : Status.SUCCESS_CREATED;
 		getResponse().setStatus(status);
 
 		String redirectUrl = "/" + resourceUri;

--- a/jar-service/src/main/java/com/sixsq/slipstream/resource/ServiceCatalogsResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/resource/ServiceCatalogsResource.java
@@ -85,7 +85,7 @@ public class ServiceCatalogsResource extends SimpleResource {
 
 		try {
 			result = new StringRepresentation(HtmlUtil.toHtml(retrieveServiceCatalogs(), getPageRepresentation(),
-					getTransformationType(), getUser()), MediaType.TEXT_HTML);
+					getUser(), getRequest()), MediaType.TEXT_HTML);
 		} catch (ValidationException e) {
 			throwClientValidationError(e.getMessage());
 		}

--- a/jar-service/src/main/java/com/sixsq/slipstream/resource/SimpleRepresentationBaseResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/resource/SimpleRepresentationBaseResource.java
@@ -57,7 +57,7 @@ public abstract class SimpleRepresentationBaseResource extends BaseResource {
 	protected String generateHtml() {
 		
 		return HtmlUtil.toHtml(getMessage(),
-				getPageRepresentation(), getUser());
+				getPageRepresentation(), getUser(), getRequest());
 
 	}
 

--- a/jar-service/src/main/java/com/sixsq/slipstream/resource/SimpleResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/resource/SimpleResource.java
@@ -36,10 +36,8 @@ public abstract class SimpleResource extends ModuleListResource {
 
 		ModuleViewList moduleViewList = retrieveFilteredModuleViewList();
 
-		return new StringRepresentation(
-				HtmlUtil.toHtml(moduleViewList,
-						getPageRepresentation(), getTransformationType(), getUser()),
-				MediaType.TEXT_HTML);
+		return new StringRepresentation(HtmlUtil.toHtml(moduleViewList, getPageRepresentation(),
+				getUser(), getRequest()), MediaType.TEXT_HTML);
 	}
 
 	protected abstract String getPageRepresentation();

--- a/jar-service/src/main/java/com/sixsq/slipstream/resource/WelcomeResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/resource/WelcomeResource.java
@@ -44,9 +44,8 @@ public class WelcomeResource extends SimpleResource {
 	@Get("html")
 	public Representation toHtml() {
 
-		return new StringRepresentation(HtmlUtil.toHtml(retrieveWelcome(),
-				getPageRepresentation(), getTransformationType(), getUser()),
-				MediaType.TEXT_HTML);
+		return new StringRepresentation(HtmlUtil.toHtml(retrieveWelcome(), getPageRepresentation(), getUser(),
+				getRequest()), MediaType.TEXT_HTML);
 	}
 
 	private Welcome retrieveWelcome() {
@@ -68,8 +67,7 @@ public class WelcomeResource extends SimpleResource {
 		return welcome;
 	}
 
-	private ServiceCatalogs retrieveServiceCatalogs()
-			throws ValidationException {
+	private ServiceCatalogs retrieveServiceCatalogs() throws ValidationException {
 
 		ServiceCatalogs scs = new ServiceCatalogs();
 		scs.loadAll();

--- a/jar-service/src/main/java/com/sixsq/slipstream/run/RunListResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/run/RunListResource.java
@@ -110,7 +110,7 @@ public class RunListResource extends BaseResource {
 
 		RunViewList list = new RunViewList();
 		try {
-			list.populate(getUser(), moduleResourceUri, offset, limit);
+			list.populate(getUser(), moduleResourceUri, offset, limit, getCloud());
 		} catch (ConfigurationException e) {
 			throwConfigurationException(e);
 		} catch (ValidationException e) {

--- a/jar-service/src/main/java/com/sixsq/slipstream/run/RunListResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/run/RunListResource.java
@@ -82,7 +82,7 @@ public class RunListResource extends BaseResource {
 
 	@Get("txt")
 	public Representation toTxt() {
-		RunViewList runViewList = getRunViewList(getOffset(), getLimit());
+		RunViewList runViewList = getRunViewList();
 		String result = SerializationUtil.toXmlString(runViewList);
 		return new StringRepresentation(result);
 	}
@@ -90,7 +90,7 @@ public class RunListResource extends BaseResource {
 	@Get("xml")
 	public Representation toXml() {
 
-		RunViewList runViewList = getRunViewList(getOffset(), getLimit());
+		RunViewList runViewList = getRunViewList();
 		String result = SerializationUtil.toXmlString(runViewList);
 		return new StringRepresentation(result, MediaType.APPLICATION_XML);
 	}
@@ -98,19 +98,19 @@ public class RunListResource extends BaseResource {
 	@Get("html")
 	public Representation toHtml() {
 
-		RunViewList runViewList = getRunViewList(getOffset(), getLimit());
+		RunViewList runViewList = getRunViewList();
 
 		return new StringRepresentation(HtmlUtil.toHtml(runViewList,
 				getPageRepresentation(), getTransformationType(), getUser()),
 				MediaType.TEXT_HTML);
 	}
 
-	private RunViewList getRunViewList(int offset, int limit) {
+	private RunViewList getRunViewList() {
 		String moduleResourceUri = getRequest().getResourceRef().getQueryAsForm().getFirstValue("moduleResourceUri");
 
 		RunViewList list = new RunViewList();
 		try {
-			list.populate(getUser(), moduleResourceUri, offset, limit, getCloud());
+			list.populate(getUser(), moduleResourceUri, getOffset(), getLimit(), getCloud());
 		} catch (ConfigurationException e) {
 			throwConfigurationException(e);
 		} catch (ValidationException e) {

--- a/jar-service/src/main/java/com/sixsq/slipstream/run/RunListResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/run/RunListResource.java
@@ -105,7 +105,7 @@ public class RunListResource extends BaseResource {
 		RunViewList runViewList = getRunViewList();
 
 		return new StringRepresentation(HtmlUtil.toHtml(runViewList,
-				getPageRepresentation(), getTransformationType(), getUser()),
+				getPageRepresentation(), getUser(), getRequest()),
 				MediaType.TEXT_HTML);
 	}
 

--- a/jar-service/src/main/java/com/sixsq/slipstream/run/RunResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/run/RunResource.java
@@ -120,7 +120,7 @@ public class RunResource extends RunBaseResource {
 			Run run = constructRun(em);
 			logTimeDiff("constructRun", before);
 			before = System.currentTimeMillis();
-			html = HtmlUtil.toHtml(run, getPageRepresentation(), getUser());
+			html = HtmlUtil.toHtml(run, getPageRepresentation(), getUser(), getRequest());
 			logTimeDiff("html generation", before);
 		} catch (SlipStreamClientException e) {
 			throw new ResourceException(Status.CLIENT_ERROR_CONFLICT,

--- a/jar-service/src/main/java/com/sixsq/slipstream/run/Vms.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/run/Vms.java
@@ -43,6 +43,9 @@ public class Vms {
 	@Attribute(required=false)
 	private int count;
 
+	@Attribute(required=false)
+	private String cloud;
+
 	@ElementList(inline = true)
 	private List<Vm> vms = new ArrayList<Vm>();
 
@@ -50,15 +53,16 @@ public class Vms {
 		return vms;
 	}
 
-	public void populate(User user, int offset, int limit) throws SlipStreamException {
-		populateVms(user, offset, limit);
+	public void populate(User user, int offset, int limit, String cloudServiceName) throws SlipStreamException {
+		populateVms(user, offset, limit, cloudServiceName);
 	}
 
-	private void populateVms(User user, int offset, int limit) throws SlipStreamException {
+	private void populateVms(User user, int offset, int limit, String cloudServiceName) throws SlipStreamException {
 		this.offset = offset;
 		this.limit = limit;
+		this.cloud = cloudServiceName;
 
-		count = Vm.listCount(user.getName());
-		vms = Vm.list(user.getName(), offset, limit);
+		count = Vm.listCount(user.getName(), cloudServiceName);
+		vms = Vm.list(user.getName(), offset, limit, cloudServiceName);
 	}
 }

--- a/jar-service/src/main/java/com/sixsq/slipstream/run/Vms.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/run/Vms.java
@@ -9,9 +9,9 @@ package com.sixsq.slipstream.run;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@ package com.sixsq.slipstream.run;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
 
@@ -33,6 +34,15 @@ import com.sixsq.slipstream.persistence.Vm;
 @Root
 public class Vms {
 
+	@Attribute(required=false)
+	private int offset;
+
+	@Attribute(required=false)
+	private int limit;
+
+	@Attribute(required=false)
+	private int count;
+
 	@ElementList(inline = true)
 	private List<Vm> vms = new ArrayList<Vm>();
 
@@ -40,11 +50,15 @@ public class Vms {
 		return vms;
 	}
 
-	public void populate(User user) throws SlipStreamException {
-		populateVms(user);
+	public void populate(User user, int offset, int limit) throws SlipStreamException {
+		populateVms(user, offset, limit);
 	}
 
-	private void populateVms(User user) throws SlipStreamException {
-		vms = Vm.list(user.getName());
+	private void populateVms(User user, int offset, int limit) throws SlipStreamException {
+		this.offset = offset;
+		this.limit = limit;
+
+		count = Vm.listCount(user.getName());
+		vms = Vm.list(user.getName(), offset, limit);
 	}
 }

--- a/jar-service/src/main/java/com/sixsq/slipstream/run/VmsResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/run/VmsResource.java
@@ -53,7 +53,7 @@ public class VmsResource extends BaseResource {
 		Vms vms = new Vms();
 
 		try {
-			vms.populate(getUser(), getOffset(), getLimit());
+			vms.populate(getUser(), getOffset(), getLimit(), getCloud());
 		} catch (SlipStreamClientException e) {
 		} catch (SlipStreamException e) {
 		}

--- a/jar-service/src/main/java/com/sixsq/slipstream/run/VmsResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/run/VmsResource.java
@@ -9,9 +9,9 @@ package com.sixsq.slipstream.run;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,22 +44,20 @@ public class VmsResource extends BaseResource {
 	@Get("html")
 	public Representation toHtml() {
 
-		String html = HtmlUtil.toHtml(getVms(),
-				getPageRepresentation(), getUser());
-		
+		String html = HtmlUtil.toHtml(getVms(), getPageRepresentation(), getUser());
+
 		return new StringRepresentation(html, MediaType.TEXT_HTML);
 	}
 
 	private Vms getVms() {
-	
 		Vms vms = new Vms();
-		
+
 		try {
-			vms.populate(getUser());
+			vms.populate(getUser(), getOffset(), getLimit());
 		} catch (SlipStreamClientException e) {
 		} catch (SlipStreamException e) {
 		}
-	
+
 		return vms;
 	}
 

--- a/jar-service/src/main/java/com/sixsq/slipstream/run/VmsResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/run/VmsResource.java
@@ -44,7 +44,7 @@ public class VmsResource extends BaseResource {
 	@Get("html")
 	public Representation toHtml() {
 
-		String html = HtmlUtil.toHtml(getVms(), getPageRepresentation(), getUser());
+		String html = HtmlUtil.toHtml(getVms(), getPageRepresentation(), getUser(), getRequest());
 
 		return new StringRepresentation(html, MediaType.TEXT_HTML);
 	}

--- a/jar-service/src/main/java/com/sixsq/slipstream/run/VmsRouter.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/run/VmsRouter.java
@@ -9,9 +9,9 @@ package com.sixsq.slipstream.run;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,21 +22,12 @@ package com.sixsq.slipstream.run;
 
 import org.restlet.Context;
 import org.restlet.routing.Router;
-import org.restlet.routing.TemplateRoute;
-import org.restlet.routing.Variable;
-
 import com.sixsq.slipstream.exceptions.ConfigurationException;
 
 public class VmsRouter extends Router {
 
 	public VmsRouter(Context context) throws ConfigurationException {
 		super(context);
-
-		TemplateRoute route;
-		route = attach("?cloud={cloudServiceName}", VmsResource.class);
-		route.setMatchingQuery(true);
-		route.getTemplate().getVariables()
-				.put("cloudServiceName", new Variable(Variable.TYPE_URI_QUERY));
 
 		attach("", VmsResource.class);
 		attach("/", VmsResource.class);

--- a/jar-service/src/main/java/com/sixsq/slipstream/user/UserListResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/user/UserListResource.java
@@ -63,7 +63,7 @@ public class UserListResource extends BaseResource {
 
 		UserViewList userViewList = new UserViewList(User.viewList());
 
-		String html = HtmlUtil.toHtml(userViewList, getPageRepresentation(), getUser());
+		String html = HtmlUtil.toHtml(userViewList, getPageRepresentation(), getUser(), getRequest());
 
 		return new StringRepresentation(html, MediaType.TEXT_HTML);
 	}

--- a/jar-service/src/main/java/com/sixsq/slipstream/util/HtmlUtil.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/util/HtmlUtil.java
@@ -20,6 +20,9 @@
 
 package com.sixsq.slipstream.util;
 
+import java.util.Map;
+
+import org.restlet.Request;
 import org.restlet.data.Status;
 import org.restlet.resource.ResourceException;
 import org.w3c.dom.Document;
@@ -30,48 +33,43 @@ import com.sixsq.slipstream.exceptions.ConfigurationException;
 import com.sixsq.slipstream.exceptions.ValidationException;
 import com.sixsq.slipstream.persistence.User;
 
+/**
+ * For unit tests, @see HtmlUtilTest
+ * 
+ */
 public class HtmlUtil {
 
-	public static String toHtml(Object metadata, String page, User user) {
-		return toHtml(metadata, page, null, user);
+	public static String toHtml(Object metadata, String page, User user, Request request) {
+		return toHtml(metadata, page, user, RequestUtil.constructOptions(request));
 	}
 
-	public static String toHtml(Object metadata, String page, String type,
-			User user) {
-		
+	private static String toHtml(Object metadata, String page, User user, Map<String, Object> options) {
+
 		Document doc = SerializationUtil.toXmlDocument(metadata);
 
 		XmlUtil.addUser(doc, user);
 		try {
 			XmlUtil.addSystemConfiguration(doc);
 		} catch (ConfigurationException e) {
-			throw (new ResourceException(Status.SERVER_ERROR_INTERNAL,
-					e.getMessage()));
+			throw (new ResourceException(Status.SERVER_ERROR_INTERNAL, e.getMessage()));
 		} catch (ValidationException e) {
-			throw (new ResourceException(Status.CLIENT_ERROR_BAD_REQUEST,
-					e.getMessage()));
+			throw (new ResourceException(Status.CLIENT_ERROR_BAD_REQUEST, e.getMessage()));
 		}
 
 		String xml = SerializationUtil.documentToString(doc);
 		try {
-			return Representation.toHtml(xml, page, type);
+			return Representation.toHtml(xml, page, options);
 		} catch (IllegalArgumentException ex) {
-			throw (new ResourceException(Status.CLIENT_ERROR_NOT_FOUND,
-					"Unknown resource: " + page));
+			throw (new ResourceException(Status.CLIENT_ERROR_NOT_FOUND, "Unknown resource: " + page));
 		}
 	}
 
-	public static String toHtml(String metadata, String page) {
-		return HtmlUtil.toHtml(metadata, page, "");
+	public static String toHtmlError(String metadata, String error, int code, Request request) {
+		return toHtmlError(metadata, error, code, RequestUtil.constructOptions(request));
 	}
 
-	public static String toHtml(String metadata, String page, String type) {
-		return Representation.toHtml(metadata, page, type);
-	}
-
-	public static String toHtmlError(String metadata, String error, int code) {
-		return Representation
-				.toHtmlError(metadata, error, String.valueOf(code));
+	private static String toHtmlError(String metadata, String error, int code, Map<String, Object> options) {
+		return Representation.toHtmlError(metadata, error, String.valueOf(code), options);
 	}
 
 }

--- a/jar-service/src/main/java/com/sixsq/slipstream/util/RequestUtil.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/util/RequestUtil.java
@@ -1,9 +1,11 @@
 package com.sixsq.slipstream.util;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.restlet.Request;
+import org.restlet.data.Parameter;
 
 import com.sixsq.slipstream.configuration.Configuration;
 import com.sixsq.slipstream.exceptions.ConfigurationException;
@@ -11,8 +13,19 @@ import com.sixsq.slipstream.exceptions.SlipStreamRuntimeException;
 import com.sixsq.slipstream.exceptions.ValidationException;
 import com.sixsq.slipstream.persistence.ServiceConfiguration;
 import com.sixsq.slipstream.persistence.User;
+import com.sixsq.slipstream.resource.BaseResource;
 
 public class RequestUtil {
+
+	public static final String TYPE_KEY = "type";
+	public static final String TYPE_VIEW_VALUE = "view";
+	public static final String TYPE_EDIT_VALUE = "edit";
+	public static final String TYPE_NEW_VALUE = "new";
+	public static final String TYPE_CHOOSER_VALUE = "chooser";
+
+	public static final String REQUEST_KEY = "request";
+	public static final String QUERY_PARAMETERS_KEY = "query-parameters";
+	public static final String URL_KEY = "url";
 
 	public static User getUserFromRequest(Request request)
 			throws ConfigurationException, ValidationException {
@@ -87,4 +100,61 @@ public class RequestUtil {
 		}*/
 	}
 
+	/**
+	 * Options specification:
+	 * {
+	 *     type:   "chooser",     // possible values: "edit", "new", "view", chooser (default if missing: "view")
+	 *     lang:   "en",          // possible values: "en", "fr"                     (default if missing: "en")
+	 *     theme:  "helixnebula", // possible values: "helixnebula", "default"       (default if missing: "default")
+	 *     request: {
+	 *         url: "/path/to/requested/resource",
+	 *         query-parameters: {
+	 *             query-param-1-name: "query-param-1-value",
+	 *             query-param-2-name: "query-param-2-value",
+	 *             ...
+	 *         }
+	 *     }
+	 * }
+	 */
+	public static Map<String, Object> constructOptions(Request request) {
+		Map<String, Object> options = new HashMap<String, Object>();
+
+		String type = constructTransformationType(request);
+		options.put(TYPE_KEY, type);
+
+		//options.put("lang", "en"); // TODO
+		//options.put("theme", "default"); // TODO
+
+		Map<String, Object> requestMap = new HashMap<String, Object>();
+
+		requestMap.put(URL_KEY, request.getOriginalRef().getPath());
+
+		Map<String, String> queryMap = request.getResourceRef().getQueryAsForm().getValuesMap();
+		requestMap.put(QUERY_PARAMETERS_KEY, queryMap);
+
+		options.put(REQUEST_KEY, requestMap);
+
+		return options;
+	}
+	
+	private static String constructTransformationType(Request request) {
+		
+		String type = "view";
+		
+		type = setTypeIfTrue(request, BaseResource.CHOOSER_KEY, type);
+		type = setTypeIfTrue(request, BaseResource.EDIT_KEY, type);
+		type = setTypeIfTrue(request, BaseResource.NEW_KEY, type);
+		
+		return type;
+	}
+	
+	private static String setTypeIfTrue(Request request, String queryKey, String defaultType) {
+		String type = defaultType;
+		Parameter parameter = request.getResourceRef().getQueryAsForm().getFirst(queryKey);
+		if(parameter != null && "true".equals(parameter.getValue())) {
+			type = queryKey;
+		}
+		return type;
+	}
+	
 }

--- a/jar-service/src/test/java/com/sixsq/slipstream/run/RunListResourceTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/run/RunListResourceTest.java
@@ -93,10 +93,7 @@ public class RunListResourceTest extends ResourceTestBase {
 
 	}
 
-	@AfterClass
-	public static void teardownClass() throws ConfigurationException,
-			ValidationException {
-
+	private static void removeAllRuns() throws ConfigurationException, ValidationException {
 		for (Run r : Run.listAll()) {
 			try {
 				r.remove();
@@ -104,6 +101,13 @@ public class RunListResourceTest extends ResourceTestBase {
 
 			}
 		}
+	}
+
+	@AfterClass
+	public static void teardownClass() throws ConfigurationException,
+			ValidationException {
+
+		removeAllRuns();
 
 	}
 
@@ -144,6 +148,8 @@ public class RunListResourceTest extends ResourceTestBase {
 
 	@Test
 	public void testPagination() throws ValidationException, SAXException, ParserConfigurationException, IOException {
+		removeAllRuns();
+
 		Set<String> cloudServiceNamesA = new HashSet<String>();
 		cloudServiceNamesA.add("CloudA");
 		Set<String> cloudServiceNamesB = new HashSet<String>();

--- a/jar-service/src/test/java/com/sixsq/slipstream/run/RunListResourceTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/run/RunListResourceTest.java
@@ -9,9 +9,9 @@ package com.sixsq.slipstream.run;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,10 +24,16 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -40,6 +46,8 @@ import org.restlet.Response;
 import org.restlet.data.Form;
 import org.restlet.data.Status;
 import org.restlet.representation.Representation;
+import org.xml.sax.SAXException;
+import org.w3c.dom.Document;
 
 import com.sixsq.slipstream.connector.local.LocalConnector;
 import com.sixsq.slipstream.connector.local.LocalUserParametersFactory;
@@ -53,11 +61,13 @@ import com.sixsq.slipstream.persistence.ModuleParameter;
 import com.sixsq.slipstream.persistence.Node;
 import com.sixsq.slipstream.persistence.NodeParameter;
 import com.sixsq.slipstream.persistence.Run;
+import com.sixsq.slipstream.persistence.RunType;
 import com.sixsq.slipstream.persistence.RuntimeParameter;
 import com.sixsq.slipstream.persistence.User;
 import com.sixsq.slipstream.persistence.UserParameter;
 import com.sixsq.slipstream.user.UserTest;
 import com.sixsq.slipstream.util.ResourceTestBase;
+import com.sixsq.slipstream.util.XmlUtil;
 
 public class RunListResourceTest extends ResourceTestBase {
 
@@ -110,6 +120,8 @@ public class RunListResourceTest extends ResourceTestBase {
 
 		user = User.loadByName(user.getName());
 
+		createModules("overrideParmeters");
+
 	}
 
 	@After
@@ -131,6 +143,60 @@ public class RunListResourceTest extends ResourceTestBase {
 	}
 
 	@Test
+	public void testPagination() throws ValidationException, SAXException, ParserConfigurationException, IOException {
+		Set<String> cloudServiceNamesA = new HashSet<String>();
+		cloudServiceNamesA.add("CloudA");
+		Set<String> cloudServiceNamesB = new HashSet<String>();
+		cloudServiceNamesB.add("CloudA");
+		cloudServiceNamesB.add("CloudB");
+		Set<String> cloudServiceNamesC = new HashSet<String>();
+		cloudServiceNamesC.add("CloudA");
+		cloudServiceNamesC.add("CloudB");
+		cloudServiceNamesC.add("CloudC");
+
+		(new Run(deployment, RunType.Orchestration, cloudServiceNamesA, user)).store();
+		(new Run(deployment, RunType.Orchestration, cloudServiceNamesB, user)).store();
+		(new Run(deployment, RunType.Orchestration, cloudServiceNamesC, user)).store();
+		(new Run(deployment, RunType.Orchestration, cloudServiceNamesC, user)).store();
+		(new Run(deployment, RunType.Orchestration, cloudServiceNamesC, user)).store();
+
+		Response resp = getRunList(null, null, null);
+		assertEquals(resp.getStatus(), Status.SUCCESS_OK);
+		Document runs = XmlUtil.stringToDom(resp.getEntityAsText());
+		assertEquals(5, runs.getDocumentElement().getElementsByTagName("item").getLength());
+		assertEquals("5", runs.getDocumentElement().getAttribute("count"));
+		assertEquals("0", runs.getDocumentElement().getAttribute("offset"));
+		assertEquals("20", runs.getDocumentElement().getAttribute("limit"));
+
+		resp = getRunList(null, 10, "CloudB");
+		assertEquals(resp.getStatus(), Status.SUCCESS_OK);
+		runs = XmlUtil.stringToDom(resp.getEntityAsText());
+		assertEquals(4, runs.getDocumentElement().getElementsByTagName("item").getLength());
+		assertEquals("4", runs.getDocumentElement().getAttribute("count"));
+		assertEquals("10", runs.getDocumentElement().getAttribute("limit"));
+
+		resp = getRunList(1, 4, null);
+		assertEquals(resp.getStatus(), Status.SUCCESS_OK);
+		runs = XmlUtil.stringToDom(resp.getEntityAsText());
+		assertEquals(4, runs.getDocumentElement().getElementsByTagName("item").getLength());
+		assertEquals("5", runs.getDocumentElement().getAttribute("count"));
+		assertEquals("1", runs.getDocumentElement().getAttribute("offset"));
+		assertEquals("4", runs.getDocumentElement().getAttribute("limit"));
+
+		resp = getRunList(null, null, "CloudC");
+		assertEquals(resp.getStatus(), Status.SUCCESS_OK);
+		runs = XmlUtil.stringToDom(resp.getEntityAsText());
+		assertEquals(3, runs.getDocumentElement().getElementsByTagName("item").getLength());
+		assertEquals("3", runs.getDocumentElement().getAttribute("count"));
+
+		resp = getRunList(-1, null, null);
+		assertEquals(resp.getStatus(), Status.CLIENT_ERROR_BAD_REQUEST);
+
+		resp = getRunList(null, Run.MAX_NO_OF_ENTRIES + 1, null);
+		assertEquals(resp.getStatus(), Status.CLIENT_ERROR_BAD_REQUEST);
+	}
+
+	@Test
 	@Ignore
 	public void overrideParameters() throws ConfigurationException,
 			NotFoundException, AbortException, ValidationException {
@@ -147,8 +213,6 @@ public class RunListResourceTest extends ResourceTestBase {
 		user.setParameter(secretParameter);
 		user.setDefaultCloudServiceName(LocalConnector.CLOUD_SERVICE_NAME);
 		user = user.store();
-
-		createModules("overrideParmeters");
 
 		List<NodeParameter> override = new ArrayList<NodeParameter>();
 		NodeParameter parameter = new NodeParameter(PARAMETER_NAME);
@@ -251,6 +315,21 @@ public class RunListResourceTest extends ResourceTestBase {
 	private Request createPostRequest(Representation entity)
 			throws ConfigurationException, ValidationException {
 		return createPostRequest(new HashMap<String, Object>(), entity);
+	}
+
+	private Response getRunList(Integer offset, Integer limit, String cloudServiceName)
+			throws ConfigurationException, ValidationException {
+
+		Map<String, Object> attributes = new HashMap<String, Object>();
+		attributes.put(User.REQUEST_KEY, user);
+
+		Form queryString = new Form();
+		if (offset != null) queryString.set("offset", offset.toString());
+		if (limit != null) queryString.set("limit", limit.toString());
+		if (cloudServiceName != null) queryString.set("cloud", cloudServiceName);
+
+		Request req = createGetRequest("?" + queryString.getQueryString(), attributes);
+		return executeRequest(req);
 	}
 
 	private Response executeRequest(Request request) {

--- a/jar-service/src/test/java/com/sixsq/slipstream/statemachine/StateMachinetTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/statemachine/StateMachinetTest.java
@@ -56,7 +56,6 @@ import com.sixsq.slipstream.persistence.PersistenceUtil;
 import com.sixsq.slipstream.persistence.Run;
 import com.sixsq.slipstream.persistence.RunType;
 import com.sixsq.slipstream.persistence.User;
-import com.sixsq.slipstream.run.RunView;
 import com.sixsq.slipstream.util.CommonTestUtil;
 
 public class StateMachinetTest {
@@ -83,14 +82,12 @@ public class StateMachinetTest {
 	public static void tearDownAfterClass() throws ValidationException {
 		CommonTestUtil.deleteUser(user);
 		removeRuns();
-		List<RunView> runs = Run.viewListAll();
+		List<Run> runs = Run.listAll();
 		assertEquals(0, runs.size());
 	}
 
 	private static void removeRuns() throws ValidationException {
-		Run run;
-		for (RunView runView : Run.viewListAll()) {
-			run = Run.load(runView.resourceUri);
+		for (Run run : Run.listAll()) {
 			run.remove();
 		}
 	}

--- a/jar-service/src/test/java/com/sixsq/slipstream/util/RequestUtilTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/util/RequestUtilTest.java
@@ -1,0 +1,100 @@
+package com.sixsq.slipstream.util;
+
+/*
+ * +=================================================================+
+ * SlipStream Server (WAR)
+ * =====
+ * Copyright (C) 2013 SixSq Sarl (sixsq.com)
+ * =====
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -=================================================================-
+ */
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.restlet.Request;
+import org.restlet.data.Method;
+import org.restlet.data.Reference;
+
+public class RequestUtilTest extends ResourceTestBase {
+
+	@Test
+	public void constructEditOptions() {
+
+		Request r = createRequest("/something", "edit=true");
+		Map<String, Object> options = RequestUtil.constructOptions(r);
+		assertThat((String) options.get(RequestUtil.TYPE_KEY), is("edit"));
+
+	}
+
+	@Test
+	public void constructNewOptions() {
+
+		Request r = createRequest("/something", "new=true");
+		Map<String, Object> options = RequestUtil.constructOptions(r);
+		assertThat((String) options.get(RequestUtil.TYPE_KEY), is("new"));
+
+	}
+
+	@Test
+	public void constructChooserOptions() {
+
+		Request r = createRequest("/something", "chooser=true");
+		Map<String, Object> options = RequestUtil.constructOptions(r);
+		assertThat((String) options.get(RequestUtil.TYPE_KEY), is("chooser"));
+
+	}
+
+	@Test
+	public void constructDefaultTypeOptions() {
+
+		Request r = createRequest("/something", null);
+		Map<String, Object> options = RequestUtil.constructOptions(r);
+		assertThat((String) options.get(RequestUtil.TYPE_KEY), is("view"));
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void constructUrlOptions() {
+
+		Request r = createRequest("/something", "query=value");
+		Map<String, Object> options = RequestUtil.constructOptions(r);
+		assertThat((String) ((Map<String, Object>) options.get(RequestUtil.REQUEST_KEY)).get(RequestUtil.URL_KEY),
+				is("/something"));
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void constructQueryParametersOptions() {
+	
+		Request r = createRequest("/something", "query1=value1&query2=value2");
+		Map<String, Object> options = RequestUtil.constructOptions(r);
+		Map<String, String> queryParameters = (Map<String,String>)((Map<String,Object>)options.get(RequestUtil.REQUEST_KEY)).get(RequestUtil.QUERY_PARAMETERS_KEY);
+		assertThat(queryParameters.size(), is(2));
+		assertThat(queryParameters.get("query1"), is("value1"));
+	}
+
+	private Request createRequest(String path, String query) {
+
+		String url = path + (query != null ? ("?" + query) : "");
+		Request r = new Request(Method.GET, url);
+		r.setOriginalRef(new Reference(path));
+		return r;
+	}
+}

--- a/jar-service/src/test/java/com/sixsq/slipstream/util/ResourceTestBase.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/util/ResourceTestBase.java
@@ -160,6 +160,12 @@ public class ResourceTestBase extends RunTestBase {
 		return createRequest(attributes, method);
 	}
 
+	protected Request createGetRequest(String targetUrl, Map<String, Object> attributes)
+			throws ConfigurationException, ValidationException {
+		Method method = Method.GET;
+		return createRequest(attributes, method, null, targetUrl);
+	}
+
 	protected Request createPutRequest(Map<String, Object> attributes,
 			Representation entity) throws ConfigurationException,
 			ValidationException {


### PR DESCRIPTION
Added pagination support for the following resources:
- `/vms`
- `/run`
- `/dashboard`

The implementation is made via 2 parameters: `offset` and `limit`
On the reply there is 3 attributes that allow to render a pagination footer: `offset`, `limit`, `count`.
On all of these resources you can filter by Cloud service with the parameter `cloud`.
On the `/run` resource you can find Runs for a specific module with the parameter `moduleResourceUri`.

**Example:**
GET on https://slipstream.sixsq.com/run?media=xml&offset=10&limit=5
```xml
<vms offset="10" limit="5" count="19">
    <vm cloud="CloudC" user="bob" state="Running" instanceId="4f2708e1-6aa6-4469-8f5e-b18ffd42cb50_machine" measurement="2014-12-08 13:09:24.82 CET" runUuid="a1b345f0-c434-490e-849f-c3894af55588"/>
    <vm cloud="CloudC" user="bob" state="Terminated" instanceId="157701e9-9c52-45b1-a506-13241446aad3_machine" measurement="2014-12-08 13:09:24.98 CET" runUuid="a1b345f0-c434-490e-849f-c3894af55588"/>
    <vm cloud="CloudA" user="bob" state="Running" instanceId="vm_gateway" measurement="2014-12-08 13:09:24.112 CET" runUuid="35c3789f-5da1-4504-8294-d41489d035ae"/>
    <vm cloud="CloudA" user="bob" state="Running" instanceId="vApp_6_centos" measurement="2014-12-08 13:09:24.126 CET" runUuid="Unknown"/>
    <vm cloud="CloudB" user="bob" state="Running" instanceId="1b0afd4f-340d-4bef-89e2-d6f4a776f2ea" measurement="2014-12-08 13:09:33.215 CET" runUuid="Unknown"/>
</vms>
```