### PR TITLE
Prevention of concurrent collection requests for the same user/cloud pair.

### DIFF
--- a/jar-async/pom.xml
+++ b/jar-async/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>com.sixsq.slipstream</groupId>
 		<artifactId>SlipStreamServer</artifactId>
-		<version>2.4.1</version>
+		<version>2.4.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/jar-async/pom.xml
+++ b/jar-async/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>com.sixsq.slipstream</groupId>
 		<artifactId>SlipStreamServer</artifactId>
-		<version>2.4.1-SNAPSHOT</version>
+		<version>2.4.1</version>
 	</parent>
 
 	<dependencies>

--- a/jar-async/src/slipstream/async/collector.clj
+++ b/jar-async/src/slipstream/async/collector.clj
@@ -68,9 +68,13 @@
 ; This is the channel for queuing all user requests
 (def all-collector-chan (chan (sliding-buffer collector-chan-size)))
 
+(defn- user-connector
+  [user connector]
+  (apply str "[user " (get-name user) " on cloud " (.getConnectorInstanceName connector) "]"))
+
 (defn- build-msg
   [user connector elapsed & info]
-  (apply str "[user " (get-name user) " on cloud " (.getConnectorInstanceName connector) "] (" elapsed " ms) : " info))
+  (apply str (user-connector user connector) " (" elapsed " ms) : " info))
 
 (defn log-timeout
   [user connector elapsed]
@@ -146,7 +150,7 @@
             c connectors]
       (if-not (@busy [(get-name u) c])
         (go (>! chan [u c]))
-        (log/log-info "Avoiding working on " (build-user-connector-msg u c) " being in a process." )))))
+        (log/log-info "Avoiding working on " (user-connector u c) " being in a process." )))))
 
 ; Start collector writers
 (defn collect-writers

--- a/jar-connector/pom.xml
+++ b/jar-connector/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>com.sixsq.slipstream</groupId>
 		<artifactId>SlipStreamServer</artifactId>
-		<version>2.4.1</version>
+		<version>2.4.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/jar-connector/pom.xml
+++ b/jar-connector/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>com.sixsq.slipstream</groupId>
 		<artifactId>SlipStreamServer</artifactId>
-		<version>2.4.1-SNAPSHOT</version>
+		<version>2.4.1</version>
 	</parent>
 
 	<dependencies>

--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/CliConnectorBase.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/CliConnectorBase.java
@@ -48,7 +48,7 @@ public abstract class CliConnectorBase extends ConnectorBase {
 
 	private static final int TIMEOUT_DEFAULT_LIST_SEC = 30;
 	private static final int TIMEOUT_DEFAULT_RUN_SEC = 600;
-	private static final int TIMEOUT_DEFAULT_TERMINATE_SEC = 600;
+	private static final int TIMEOUT_DEFAULT_TERMINATE_SEC = 900;
 
 	protected Logger log;
 

--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/Collector.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/Collector.java
@@ -84,7 +84,7 @@ public class Collector {
 		}
 
 		int vmsPopulated = populateVmsForCloud(user, connector.getConnectorInstanceName(), props);
-		log(user, connector, describeStopTime, "describe VMs done.");
+		log(user, connector, describeStopTime, "populate DB VMs done.");
 		return vmsPopulated;
 	}
 

--- a/jar-persistence/pom.xml
+++ b/jar-persistence/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>com.sixsq.slipstream</groupId>
 		<artifactId>SlipStreamServer</artifactId>
-		<version>2.4.1</version>
+		<version>2.4.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/jar-persistence/pom.xml
+++ b/jar-persistence/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>com.sixsq.slipstream</groupId>
 		<artifactId>SlipStreamServer</artifactId>
-		<version>2.4.1-SNAPSHOT</version>
+		<version>2.4.1</version>
 	</parent>
 
 	<dependencies>

--- a/jar-service/pom.xml
+++ b/jar-service/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>com.sixsq.slipstream</groupId>
 		<artifactId>SlipStreamServer</artifactId>
-		<version>2.4.1</version>
+		<version>2.4.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/jar-service/pom.xml
+++ b/jar-service/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>com.sixsq.slipstream</groupId>
 		<artifactId>SlipStreamServer</artifactId>
-		<version>2.4.1-SNAPSHOT</version>
+		<version>2.4.1</version>
 	</parent>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>SlipStreamServer</artifactId>
-  <version>2.4.1-SNAPSHOT</version>
+  <version>2.4.1</version>
   <packaging>pom</packaging>
   <name>SlipStream Server</name>
   <url>http://sixsq.com/</url>
@@ -49,7 +49,7 @@
     <connection>${scm.read}/SlipStreamServer.git</connection>
     <developerConnection>${scm.write}/SlipStreamServer.git</developerConnection>
     <url>${scm.public}/SlipStreamServer.git</url>
-    <tag>HEAD</tag>
+    <tag>v2.4.1</tag>
   </scm>
 
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>SlipStreamServer</artifactId>
-  <version>2.4.1</version>
+  <version>2.4.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>SlipStream Server</name>
   <url>http://sixsq.com/</url>
@@ -49,7 +49,7 @@
     <connection>${scm.read}/SlipStreamServer.git</connection>
     <developerConnection>${scm.write}/SlipStreamServer.git</developerConnection>
     <url>${scm.public}/SlipStreamServer.git</url>
-    <tag>v2.4.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.sixsq.slipstream</groupId>
     <artifactId>SlipStream</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.2-SNAPSHOT</version>
     <relativePath>../SlipStream</relativePath>
   </parent>
 

--- a/rpm/pom.xml
+++ b/rpm/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.sixsq.slipstream</groupId>
         <artifactId>SlipStreamServer</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
     </parent>
     <dependencies>
         <dependency>

--- a/rpm/pom.xml
+++ b/rpm/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.sixsq.slipstream</groupId>
         <artifactId>SlipStreamServer</artifactId>
-        <version>2.4.1</version>
+        <version>2.4.2-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>

--- a/static-content/pom.xml
+++ b/static-content/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.sixsq.slipstream</groupId>
     <artifactId>SlipStreamServer</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.2-SNAPSHOT</version>
   </parent>
   
   <dependencies>

--- a/static-content/pom.xml
+++ b/static-content/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.sixsq.slipstream</groupId>
     <artifactId>SlipStreamServer</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <dependencies>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.sixsq.slipstream</groupId>
     <artifactId>SlipStreamServer</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.2-SNAPSHOT</version>
   </parent>
   
   <dependencies>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.sixsq.slipstream</groupId>
     <artifactId>SlipStreamServer</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <dependencies>


### PR DESCRIPTION
DONE
- Prevention of concurrent collection requests for the same user/cloud pair.
- Spaced out collection requests during the refresh period.
- Propagation of timeout from Clojure collector to Java and up to Python CLI.
- Enhanced logging.

TODO
- Enforce uniqueness constraint in VM table https://github.com/slipstream/SlipStreamServer/issues/239
- Implement forceful termination of launched CLI after a timeout in Java ProcessUtils (connector) https://github.com/slipstream/SlipStreamServer/issues/240
