### PR TITLE
Fix #265 improve logging

### DIFF
--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/CliConnectorBase.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/CliConnectorBase.java
@@ -147,7 +147,7 @@ public abstract class CliConnectorBase extends ConnectorBase {
 		String[] commands = { "sh", "-c", command };
 
 		try {
-			result = ProcessUtils.execGetOutput(commands, getCommonEnvironment(user));
+			result = ProcessUtils.execGetOutput(commands, getCommonEnvironment(user), false);
 		} catch (IOException e) {
 			e.printStackTrace();
 			throw (new SlipStreamInternalException(e));

--- a/jar-connector/src/main/java/com/sixsq/slipstream/util/ProcessUtils.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/util/ProcessUtils.java
@@ -24,6 +24,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.sixsq.slipstream.exceptions.ProcessException;
@@ -43,6 +44,11 @@ public class ProcessUtils {
 		return execGetOutputAsArray(command, true, environment)[0];
 	}
 
+	public static String execGetOutput(String[] command, Map<String, String> environment, boolean isFailureCritical)
+			throws IOException, SlipStreamClientException {
+		return execGetOutputAsArray(command, true, environment, isFailureCritical)[0];
+	}
+
 	public static String execGetOutput(String[] command, boolean stderrToStdout)
 			throws IOException, SlipStreamClientException {
 		return execGetOutputAsArray(command, stderrToStdout)[0];
@@ -60,6 +66,11 @@ public class ProcessUtils {
 
 	public static String[] execGetOutputAsArray(String[] command, boolean stderrToStdout,
 			Map<String, String> environment) throws IOException, SlipStreamClientException {
+		return execGetOutputAsArray(command, stderrToStdout, environment, true);
+	}
+
+	public static String[] execGetOutputAsArray(String[] command, boolean stderrToStdout,
+			Map<String, String> environment, boolean isFailureCritical) throws IOException, SlipStreamClientException {
 
 		StringBuilder commandMessage = new StringBuilder();
 		for (String part : command) {
@@ -91,13 +102,13 @@ public class ProcessUtils {
 		while ((line = stdOutErr.readLine()) != null) {
 			outputBuf.append(line);
 			outputBuf.append("\n");
-			getLogger().fine(line);
+			getLogger().finest(line);
 		}
 
 		while ((line = stdErrReader.readLine()) != null) {
 			errBuf.append(line);
 			errBuf.append("\n");
-			getLogger().fine(line);
+			getLogger().finest(line);
 		}
 
 		// Check for failure
@@ -107,7 +118,7 @@ public class ProcessUtils {
 						+ ". With exit code = " + p.exitValue()
 						+ " and stdout: " + outputBuf
 						+ " and stderr: " + errBuf;
-				getLogger().severe(error);
+				getLogger().log((isFailureCritical)? Level.SEVERE : Level.WARNING, error);
 				String message = (stderrToStdout)? outputBuf.toString() : errBuf.toString();
 				throw (new ProcessException(message, outputBuf.toString()));
 			}

--- a/jar-service/src/main/java/com/sixsq/slipstream/main/Main.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/main/Main.java
@@ -54,6 +54,9 @@ public class Main {
 			log.severe("Starting SlipStream FAILED!");
 			System.exit(1);
 		}
+		log.finest("SlipStream started!");
+		log.finer("SlipStream started!");
+		log.fine("SlipStream started!");
 		log.info("SlipStream started!");
 	}
 

--- a/rpm/src/main/jetty-config/resources/logging.properties
+++ b/rpm/src/main/jetty-config/resources/logging.properties
@@ -3,7 +3,7 @@ handlers=java.util.logging.FileHandler
 
 .level=FINE
 
-java.util.logging.SimpleFormatter.format=%1$tD %1$tT.%1$tL %1$tZ %4$s %2$s %5$s %n %6$s
+java.util.logging.SimpleFormatter.format=%1$tFT%1$tT.%1$tL%1$tz %4$s %2$s %5$s %n %6$s
 
 java.util.logging.FileHandler.level=INFO
 java.util.logging.FileHandler.pattern=logs/slipstream.log

--- a/rpm/src/main/jetty-config/resources/logging.properties
+++ b/rpm/src/main/jetty-config/resources/logging.properties
@@ -1,6 +1,10 @@
 handlers=java.util.logging.FileHandler
 #handlers=java.util.logging.FileHandler, net.kencochrane.raven.jul.SentryHandler
 
+.level=FINE
+
+java.util.logging.SimpleFormatter.format=%1$tD %1$tT.%1$tL %1$tZ %4$s %2$s %5$s %n %6$s
+
 java.util.logging.FileHandler.level=INFO
 java.util.logging.FileHandler.pattern=logs/slipstream.log
 
@@ -12,4 +16,7 @@ java.util.logging.FileHandler.count=4
 java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
 
 #net.kencochrane.raven.jul.SentryHandler.dsn=
-#net.kencochrane.raven.jul.SentryHandler.level=WARNING
+#net.kencochrane.raven.jul.SentryHandler.level=SEVERE
+
+org.hibernate.level=INFO
+


### PR DESCRIPTION
Corresponding issue #265 

@st @loomis @mebster @konstan @rbf : Can you give your opinion about the new log format ?
And if one of you can review other changes of this pull request.

The new log format look like this:
```bash
03/11/15 00:49:07.989 CET INFO com.sixsq.slipstream.util.Logger info No users to collect for online users 
03/11/15 22:49:08.481 CET INFO com.sixsq.slipstream.util.Logger info Inserting collect request for [sixsq/Exoscale] 1426117748481  after timeout 150832 
03/11/15 22:49:08.482 CET INFO com.sixsq.slipstream.util.Logger info executing collect request for sixsq and Exoscale 
03/11/15 22:49:43.434 CET INFO com.sixsq.slipstream.connector.Collector logTiming [super/Exoscale] (666 ms) : describe VMs done. 
03/11/15 22:49:43.437 CET INFO com.sixsq.slipstream.connector.Collector logTiming [super/Exoscale] (3 ms) : populate DB VMs done.
03/11/15 22:57:46.207 CET INFO com.sixsq.slipstream.util.ProcessUtils execGetOutputAsArray Calling: sh -c /usr/bin/nuvlabox-describe-instances  -t 60 --username 'ssuser' --endpoint 'https://nuvlabox:2634/one-proxy/xmlrpc'   
03/11/15 22:57:46.667 CET WARNING com.sixsq.slipstream.util.ProcessUtils execGetOutputAsArray Error executing: sh -c /usr/bin/nuvlabox-describe-instances  -t 60 --username 'ssuser' --endpoint 'https://nuvlabox:2634/one-proxy/xmlrpc'  . With exit code = 2 and stdout: <ProtocolError for ssuser@nuvlabox:2634/one-proxy/pswd/xmlrpc: 401 Unauthorized> and stderr:  
03/11/15 22:57:46.669 CET WARNING com.sixsq.slipstream.connector.Collector describeInstances Failed contacting cloud [SlipStreamRuntimeException]: [nuvlabox/nuvlabox] with '<ProtocolError for ssuser:@nuvlabox:2634/one-proxy/pswd/xmlrpc: 401 Unauthorized>'```