### PR TITLE
Issue #267 - Execute image creation recipes during the Executing state if the image wasn't built.

### DIFF
--- a/jar-connector/src/main/java/com/sixsq/slipstream/factory/DeploymentFactory.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/factory/DeploymentFactory.java
@@ -117,7 +117,7 @@ public class DeploymentFactory extends RunFactory {
 			String referenceUri = image.getModuleReference();
 			ImageModule reference = (ImageModule) ImageModule.load(referenceUri);
 			if (reference == null) {
-				throw new ValidationException("Image " + image.getName() + " refers to an unknown image "
+				throw new ValidationException(image.getName() + " referring to an unknown image "
 						+ image.getModuleReference());
 			}
 			checkImageHasReferenceOrImageId(reference, cloudServiceName);

--- a/jar-connector/src/main/java/com/sixsq/slipstream/factory/DeploymentFactory.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/factory/DeploymentFactory.java
@@ -32,6 +32,7 @@ import com.sixsq.slipstream.exceptions.NotFoundException;
 import com.sixsq.slipstream.exceptions.SlipStreamClientException;
 import com.sixsq.slipstream.exceptions.SlipStreamInternalException;
 import com.sixsq.slipstream.exceptions.ValidationException;
+import com.sixsq.slipstream.persistence.CloudImageIdentifier;
 import com.sixsq.slipstream.persistence.DeploymentModule;
 import com.sixsq.slipstream.persistence.ImageModule;
 import com.sixsq.slipstream.persistence.Module;
@@ -98,28 +99,25 @@ public class DeploymentFactory extends RunFactory {
 		}
 	}
 
-	private static void checkImageHasReferenceOrImageId(ImageModule image,
-			String cloudServiceName) throws ValidationException {
+	private static void checkImageHasReferenceOrImageId(ImageModule image, String cloudServiceName)
+			throws ValidationException {
 
 		if (!"".equals(image.getCloudImageId(cloudServiceName))) {
 			return;
 		}
-		boolean mustHaveImageId = image.isBase() || !image.isVirtual();
-		if (mustHaveImageId
-				&& "".equals(image.getCloudImageId(cloudServiceName))) {
-			throw new ValidationException(image.getName()
-					+ " missing an image id for cloud: " + cloudServiceName
-					+ ". Did you build it?");
+
+		boolean mustHaveImageId = image.isBase();
+		if (mustHaveImageId && "".equals(image.getCloudImageId(cloudServiceName))) {
+			throw new ValidationException(image.getName() + " missing an image id for cloud: " + cloudServiceName);
+
 		} else if (image.getModuleReference() == null || "".equals(image.getModuleReference())) {
-			throw new ValidationException(image.getName()
-					+ " missing a machine image reference");
+			throw new ValidationException(image.getName() + " missing a machine image reference");
+
 		} else {
 			String referenceUri = image.getModuleReference();
-			ImageModule reference = (ImageModule) ImageModule
-					.load(referenceUri);
+			ImageModule reference = (ImageModule) ImageModule.load(referenceUri);
 			if (reference == null) {
-				throw new ValidationException("Image " + image.getName()
-						+ " refers to an unknown image "
+				throw new ValidationException("Image " + image.getName() + " refers to an unknown image "
 						+ image.getModuleReference());
 			}
 			checkImageHasReferenceOrImageId(reference, cloudServiceName);
@@ -390,8 +388,7 @@ public class DeploymentFactory extends RunFactory {
 		return (DeploymentModule) module;
 	}
 
-	private String resolveCloudServiceNameForNode(User user, List<Parameter<?>> userChoicesForNode,
-			Node node) {
+	private String resolveCloudServiceNameForNode(User user, List<Parameter<?>> userChoicesForNode, Node node) {
 		String cloudService = null;
 
 		if (userChoicesForNode != null) {
@@ -432,6 +429,14 @@ public class DeploymentFactory extends RunFactory {
 			insertNewRunParameterForNode(run, node,
 					RunParameter.NODE_INCREMENT_KEY, String.valueOf(multiplicity + 1),
 					RunParameter.NODE_INCREMENT_DESCRIPTION);
+
+			String cloudService = run.getParameterValue(constructParamName(
+					node.getName(),
+					RuntimeParameter.CLOUD_SERVICE_NAME), CloudImageIdentifier.DEFAULT_CLOUD_SERVICE);
+			boolean runBuildRecipes = node.getImage().hasToRunBuildRecipes(cloudService);
+			insertNewRunParameterForNode(run, node,
+					RunParameter.NODE_RUN_BUILD_RECIPES_KEY, String.valueOf(runBuildRecipes),
+					RunParameter.NODE_RUN_BUILD_RECIPES_DESCRIPTION);
 		}
 	}
 

--- a/jar-connector/src/main/java/com/sixsq/slipstream/factory/SimpleRunFactory.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/factory/SimpleRunFactory.java
@@ -23,9 +23,14 @@ package com.sixsq.slipstream.factory;
 import java.util.Map;
 
 import com.sixsq.slipstream.exceptions.SlipStreamClientException;
+import com.sixsq.slipstream.exceptions.ValidationException;
+import com.sixsq.slipstream.persistence.CloudImageIdentifier;
 import com.sixsq.slipstream.persistence.ImageModule;
 import com.sixsq.slipstream.persistence.Module;
+import com.sixsq.slipstream.persistence.Run;
+import com.sixsq.slipstream.persistence.RunParameter;
 import com.sixsq.slipstream.persistence.RunType;
+import com.sixsq.slipstream.persistence.RuntimeParameter;
 
 public class SimpleRunFactory extends BuildImageFactory {
 
@@ -44,6 +49,21 @@ public class SimpleRunFactory extends BuildImageFactory {
 
 		String cloudServiceName = cloudServicePerNode.get(nodeInstanceName);
 		image.validateForRun(cloudServiceName);
+	}
+
+	@Override
+	protected void initExtraRunParameters(Module module, Run run) throws ValidationException {
+		ImageModule image = (ImageModule) module;
+
+		String cloudService = run.getParameterValue(constructParamName(
+				nodeInstanceName,
+				RuntimeParameter.CLOUD_SERVICE_NAME), CloudImageIdentifier.DEFAULT_CLOUD_SERVICE);
+
+		boolean runBuildRecipes = image.hasToRunBuildRecipes(cloudService);
+
+		String runParameterName = constructParamName(nodeInstanceName, RunParameter.NODE_RUN_BUILD_RECIPES_KEY);
+		run.setParameter(new RunParameter(runParameterName, String.valueOf(runBuildRecipes),
+				RunParameter.NODE_RUN_BUILD_RECIPES_DESCRIPTION));
 	}
 
 }

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/ImageModule.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/ImageModule.java
@@ -141,11 +141,10 @@ public class ImageModule extends Module {
 			extractBaseImageId(cloudService);
 			return;
 		}
-		if (getImageId(cloudService) == null) {
-			throw new ValidationException(getName()
-					+ " missing an image id for cloud: " + cloudService
-					+ ". Did you build it?");
-		}
+	}
+
+	public boolean hasToRunBuildRecipes(String cloudService) {
+		return !isVirtual() && getImageId(cloudService) == null;
 	}
 
 	private void validateBaseImage(String cloudService, boolean throwOnError)

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/RunParameter.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/RunParameter.java
@@ -32,6 +32,8 @@ public class RunParameter extends Parameter<Run> {
 
 	public static final String NODE_INCREMENT_KEY = "node.increment";
 	public static final String NODE_INCREMENT_DESCRIPTION = "Current increment value for node instances ids";
+	public static final String NODE_RUN_BUILD_RECIPES_KEY = "run-build-recipes";
+	public static final String NODE_RUN_BUILD_RECIPES_DESCRIPTION = "Define if the SlipStream executor should run build recipes.";
 
 	@Id
 	@GeneratedValue


### PR DESCRIPTION
Fix #267.

Added a parameter on "deployment Run" and "simple Run"  to tell to the node executor if it has to run build recipes.

Corresponding pull request on SlipStreamServer: slipstream/SlipStreamClient#84
These two issues should be merged at the same time.