### PR TITLE
Fix #181 - Copy to doesn't copy all fields

### DIFF
--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Module.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Module.java
@@ -500,6 +500,7 @@ public abstract class Module extends Parameterized<Module, ModuleParameter> impl
 		copy.setCloudNames((cloudNames == null ? null : cloudNames.clone()));
 		copy.setModuleReference(getModuleReference());
 		copy.setTag(getTag());
+		copy.setLogoLink(getLogoLink());
 
 		copy.setAuthz(getAuthz().copy(copy));
 

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Node.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Node.java
@@ -293,6 +293,7 @@ public class Node extends Parameterized<Node, NodeParameter> {
 	public Node copy() throws ValidationException {
 		Node copy = new Node(getName(), getImageUri());
 		copy = (Node) copyTo(copy);
+		copy.setCloudService(getCloudService());
 		copy.setMultiplicity(getMultiplicity());
 		copy.setNetwork(getNetwork());
 		return copy;

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/NodeParameter.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/NodeParameter.java
@@ -9,9 +9,9 @@ package com.sixsq.slipstream.persistence;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -92,7 +92,7 @@ public class NodeParameter extends Parameter<Node> {
 	 * If the parameter is added to a node named 'node1' with an input parameter
 	 * 'p1' and this parameter is to be mapped to an output parameter
 	 * 'node2.1:p1' then the following parameters should take the values:
-	 * 
+	 *
 	 * @param name
 	 *            for example 'p1'
 	 * @param value
@@ -156,8 +156,7 @@ public class NodeParameter extends Parameter<Node> {
 
 	@Override
 	public NodeParameter copy() throws ValidationException {
-		NodeParameter copy = (NodeParameter) copyTo(new NodeParameter(getName(), getValue(),
-				getDescription()));
+		NodeParameter copy = (NodeParameter) copyTo(new NodeParameter(getName(), getValue(), getDescription()));
 		copy.setMappedValue(isMappedValue());
 		return copy;
 	}

--- a/jar-service/src/main/java/com/sixsq/slipstream/module/ModuleResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/module/ModuleResource.java
@@ -110,8 +110,7 @@ public class ModuleResource extends ParameterizedResource<Module> {
 		Form form = new Form(entity);
 
 		if (!isExisting()) {
-			throwClientForbiddenError("Target project doesn't exist: "
-					+ getParameterized().getName());
+			throwClientForbiddenError("Target project doesn't exist: " + getParameterized().getName());
 		}
 
 		String sourceUri = form.getFirstValue(COPY_SOURCE_FORM_PARAMETER_NAME);
@@ -130,8 +129,7 @@ public class ModuleResource extends ParameterizedResource<Module> {
 		}
 
 		if (!source.getAuthz().canGet(getUser())) {
-			throwClientForbiddenError("You do not have read rights on the source module: "
-					+ source.getName());
+			throwClientForbiddenError("You do not have read rights on the source module: " + source.getName());
 		}
 
 		String targetFullName = getParameterized().getName() + "/" + targetName;
@@ -139,8 +137,7 @@ public class ModuleResource extends ParameterizedResource<Module> {
 
 		Module target = Module.load(targetUri);
 		if (target != null) {
-			throwClientForbiddenError("Target module already exists: "
-					+ targetUri);
+			throwClientForbiddenError("Target module already exists: " + targetUri);
 		}
 
 		if (!getParameterized().getAuthz().canCreateChildren(getUser())) {


### PR DESCRIPTION
Fixed a bug where the following elements aren't copied:
- Default Cloud on Node
- Logo link

Fix #181.