### PR TITLE
Revert "Added the image parameter 'platform' as a RuntimeParameter. #312"

### DIFF
--- a/jar-connector/src/main/java/com/sixsq/slipstream/factory/BuildImageFactory.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/factory/BuildImageFactory.java
@@ -168,10 +168,6 @@ public class BuildImageFactory extends RunFactory {
 		run.assignRuntimeParameter(constructParamName(nodeInstanceName, RuntimeParameter.IMAGE_ID_PARAMETER_NAME),
 				imageId, RuntimeParameter.IMAGE_ID_PARAMETER_DESCRIPTION, ParameterType.String);
 
-		String imagePlatform = image.getPlatform();
-		run.assignRuntimeParameter(constructParamName(nodeInstanceName, RuntimeParameter.IMAGE_PLATFORM_PARAMETER_NAME),
-				imagePlatform, RuntimeParameter.IMAGE_PLATFORM_PARAMETER_DESCRIPTION, ParameterType.String);
-
 	}
 
 	private static String extractInitialValue(ModuleParameter parameter, Run run) {

--- a/jar-connector/src/main/java/com/sixsq/slipstream/factory/DeploymentFactory.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/factory/DeploymentFactory.java
@@ -42,7 +42,6 @@ import com.sixsq.slipstream.persistence.Node;
 import com.sixsq.slipstream.persistence.NodeParameter;
 import com.sixsq.slipstream.persistence.Parameter;
 import com.sixsq.slipstream.persistence.ParameterCategory;
-import com.sixsq.slipstream.persistence.ParameterType;
 import com.sixsq.slipstream.persistence.Run;
 import com.sixsq.slipstream.persistence.RunParameter;
 import com.sixsq.slipstream.persistence.RunType;
@@ -180,11 +179,6 @@ public class DeploymentFactory extends RunFactory {
 		run.createRuntimeParameter(node, nodeInstanceId,
 				RuntimeParameter.IMAGE_ID_PARAMETER_NAME, imageId,
 				RuntimeParameter.IMAGE_ID_PARAMETER_DESCRIPTION);
-
-		String imagePlatform = image.getPlatform();
-		run.createRuntimeParameter(node, nodeInstanceId,
-				RuntimeParameter.IMAGE_PLATFORM_PARAMETER_NAME, imagePlatform,
-				RuntimeParameter.IMAGE_PLATFORM_PARAMETER_DESCRIPTION);
 
 		run = initNodeInstanceRuntimeParametersFromImageParameters(run, node, nodeInstanceId);
 

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/RuntimeParameter.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/RuntimeParameter.java
@@ -113,9 +113,6 @@ public class RuntimeParameter extends Metadata {
 	public final static String IMAGE_ID_PARAMETER_NAME = "image.id";
 	public final static String IMAGE_ID_PARAMETER_DESCRIPTION = "Cloud image id";
 
-	public final static String IMAGE_PLATFORM_PARAMETER_NAME = "image.platform";
-	public final static String IMAGE_PLATFORM_PARAMETER_DESCRIPTION = "Platform (eg: ubuntu, windows)";
-
 	public final static String MULTIPLICITY_PARAMETER_NAME = "multiplicity";
 	public final static String MULTIPLICITY_PARAMETER_DESCRIPTION = "Multiplicity number";
 


### PR DESCRIPTION
This reverts commit 2f8becb10bdacadec2aa6c2196caa7724af8dd56 of PR #312.

It's not needed to add the platform as a RuntimeParameter to make Windows deployment  working because the platform is taken from the image attributes.

If you think this platform is useful as a RuntimeParameter (for example to be used with `ss-get` by a deployment script), you can close this PR.
If you think it's useless, you can merge this PR.

Connected to slipstream/SlipStreamClient#89