### PR TITLE
Allow Connectors to define if a VM is usable or not 

### DIFF
--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/Connector.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/Connector.java
@@ -141,4 +141,6 @@ public interface Connector {
 
 	boolean isCredentialsSet(User user);
 
+	boolean isVmUsable(String vmState);
+
 }

--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/ConnectorBase.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/ConnectorBase.java
@@ -503,4 +503,13 @@ public abstract class ConnectorBase implements Connector {
     	}
     	throw new ValidationException("Failed to get endpoint. Parameter not found: " + paramName);
     }
+
+    @Override
+    public boolean isVmUsable(String vmState) {
+    	return vmState != null &&
+    			("running".equals(vmState.toLowerCase())
+    			|| "active".equals(vmState.toLowerCase())
+    			|| "on".equals(vmState.toLowerCase()));
+    }
+
 }

--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/local/LocalConnector.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/local/LocalConnector.java
@@ -65,7 +65,7 @@ public class LocalConnector extends ConnectorBase {
 		vms = new ArrayList<Vm>();
 		for (int i = 0; i < MAX_VMS; i++) {
 			String randomState = randomState();
-			Vm vm = new Vm("instance_" + i, cloud, randomState, username);
+			Vm vm = new Vm("instance_" + i, cloud, randomState, username, new LocalConnector().isVmUsable(randomState));
 			vms.add(vm);
 		}
 		Collector.update(vms, username, cloud);

--- a/jar-connector/src/test/java/com/sixsq/slipstream/metering/MeteringTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/metering/MeteringTest.java
@@ -33,6 +33,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.sixsq.slipstream.connector.Collector;
+import com.sixsq.slipstream.connector.local.LocalConnector;
 import com.sixsq.slipstream.exceptions.ConfigurationException;
 import com.sixsq.slipstream.exceptions.SlipStreamException;
 import com.sixsq.slipstream.persistence.Vm;
@@ -75,7 +76,7 @@ public class MeteringTest extends RunTestBase {
 	}
 
 	private static Vm createVm(String instanceid, String cloud, String state, String user, String runId) {
-		Vm vm = new Vm(instanceid, cloud, state, user);
+		Vm vm = new Vm(instanceid, cloud, state, user, new LocalConnector().isVmUsable(state));
 		vm.setRunUuid(runId);
 		return vm;
 	}

--- a/jar-connector/src/test/java/com/sixsq/slipstream/persistence/VmRuntimeParameterMappingTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/persistence/VmRuntimeParameterMappingTest.java
@@ -36,6 +36,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.sixsq.slipstream.connector.Collector;
+import com.sixsq.slipstream.connector.Connector;
+import com.sixsq.slipstream.connector.local.LocalConnector;
 import com.sixsq.slipstream.exceptions.ValidationException;
 import com.sixsq.slipstream.run.RuntimeParameterMediator;
 
@@ -141,7 +143,7 @@ public class VmRuntimeParameterMappingTest {
 		assertThat(mapping.getInstanceId(), is(instanceId));
 
 		// Updating the vm state sets the corresponding runtime parameter
-		Vm vm = new Vm(instanceId, cloudName, vmstate, user.getName());
+		Vm vm = new Vm(instanceId, cloudName, vmstate, user.getName(), new LocalConnector().isVmUsable(vmstate));
 		Collector.update(Arrays.asList(vm), user.getName(), cloudName);
 		mapping = VmRuntimeParameterMapping.find("local", instanceId);
 		assertThat(mapping.getRunUuid(), is(run.getUuid()));
@@ -184,12 +186,14 @@ public class VmRuntimeParameterMappingTest {
 
 		int MAX_VMS = 1000;
 
+		Connector connector = new LocalConnector();
 		Random random = new Random();
 		String[] states = { "init", "run", "done", "error" };
 		random.nextInt(states.length);
 		List<Vm> vms = new ArrayList<Vm>();
 		for (int i = 0; i < MAX_VMS; i++) {
-			Vm vm = new Vm("instance_" + i, "local", states[random.nextInt(states.length)], user.getName());
+			String state = states[random.nextInt(states.length)];
+			Vm vm = new Vm("instance_" + i, "local", state, user.getName(), connector.isVmUsable(state));
 			vms.add(vm);
 		}
 		Collector.update(vms, user.getName(), "local");

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Vm.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Vm.java
@@ -355,7 +355,7 @@ public class Vm {
 	}
 
 	public boolean getIsUsable() {
-		return this.isUsable;
+		return (this.isUsable == null) ? false : this.isUsable;
 	}
 
 	public void setIsUsable(boolean isUsable) {

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Vm.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Vm.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityTransaction;
@@ -58,7 +59,7 @@ import com.sixsq.slipstream.vm.VmsQueryParameters;
 @Table(uniqueConstraints = {@UniqueConstraint(columnNames={"cloud", "instanceId", "user_"})})
 @NamedQueries({
 		@NamedQuery(name = "byUserAndCloud", query = "SELECT v FROM Vm v WHERE v.user_ = :user AND v.cloud = :cloud"),
-		@NamedQuery(name = "usageByUser", query = "SELECT v.cloud, COUNT(v.runUuid) FROM Vm v WHERE v.user_ = :user AND v.state IN ('Running', 'running', 'On', 'on', 'active', 'Active') AND v.runUuid IS NOT NULL AND v.runUuid <> 'Unknown' GROUP BY v.cloud ORDER BY v.cloud"),
+		@NamedQuery(name = "usageByUser", query = "SELECT v.cloud, COUNT(v.runUuid) FROM Vm v WHERE v.user_ = :user AND v.isUsable = 1 AND v.runUuid IS NOT NULL AND v.runUuid <> 'Unknown' GROUP BY v.cloud ORDER BY v.cloud"),
 		@NamedQuery(name = "byRun", query = "SELECT v.cloud, v FROM Vm v WHERE v.runUuid = :run")
 })
 
@@ -103,15 +104,20 @@ public class Vm {
 	@Attribute(required = false)
 	private String nodeInstanceId;
 
+	@Column(nullable = true)
+	@Attribute(required = false)
+	private Boolean isUsable;
+
 	@SuppressWarnings("unused")
 	private Vm() {
 	}
 
-	public Vm(String instanceid, String cloud, String state, String user) {
+	public Vm(String instanceid, String cloud, String state, String user, boolean isUsable) {
 		this.instanceId = instanceid;
 		this.cloud = cloud;
 		this.state = state;
 		this.user_ = user;
+		this.isUsable = isUsable;
 		measurement = new Date();
 	}
 
@@ -346,6 +352,14 @@ public class Vm {
 
 	public void setNodeInstanceId(String nodeInstanceId) {
 		this.nodeInstanceId = nodeInstanceId;
+	}
+
+	public boolean getIsUsable() {
+		return this.isUsable;
+	}
+
+	public void setIsUsable(boolean isUsable) {
+		this.isUsable = isUsable;
 	}
 
 	public void remove() {

--- a/jar-persistence/src/test/java/com/sixsq/slipstream/persistence/VmTest.java
+++ b/jar-persistence/src/test/java/com/sixsq/slipstream/persistence/VmTest.java
@@ -33,7 +33,7 @@ public class VmTest {
 		}
 		assertThat(Vm.list(user).size(), is(0));
 	}
-	
+
 	@Test
 	public void empty() throws ConfigurationException, ValidationException {
 		List<Vm> vms = new ArrayList<Vm>();
@@ -50,8 +50,8 @@ public class VmTest {
 			EntityTransaction transaction = em.getTransaction();
 			transaction.begin();
 
-			String sqlInsert1 = String.format("INSERT INTO Vm VALUES (10, 'lokal', 'instance100', null, null, null, 'up', '%s', null, null, null, null)", user);
-			String sqlInsert2 = String.format("INSERT INTO Vm VALUES (20, 'lokal', 'instance100', null, null, null, 'down', '%s', null, null, null, null)", user);
+			String sqlInsert1 = String.format("INSERT INTO Vm VALUES (10, 'lokal', 'instance100', null, null, null, 'up', '%s', null, null, null, null, null)", user);
+			String sqlInsert2 = String.format("INSERT INTO Vm VALUES (20, 'lokal', 'instance100', null, null, null, 'down', '%s', null, null, null, null, null)", user);
 
 			Query query1 = em.createNativeQuery(sqlInsert1);
 			Query query2 = em.createNativeQuery(sqlInsert2);
@@ -69,5 +69,5 @@ public class VmTest {
 		assertTrue("Second insert should have failed", exceptionOccured);
 	}
 
-	
+
 }


### PR DESCRIPTION
This is used by the `usage` and the `metering` section of the dashboard.
It's also used by the `/usage` resource.

@st: Can you check the way the `UsageRecorder` is used in `Collector.java` ?

Connected to slipstream/slipstream#52.