### PR TITLE
remove hsqldb as a runtime dependency (fixes #238)

### DIFF
--- a/jar-persistence/pom.xml
+++ b/jar-persistence/pom.xml
@@ -64,6 +64,7 @@
 		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/jar-service/pom.xml
+++ b/jar-service/pom.xml
@@ -131,15 +131,11 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- <dependency> <groupId>org.hibernate</groupId> <artifactId>hibernate-entitymanager</artifactId> 
-			</dependency> -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-jdk14</artifactId>
 		</dependency>
 
-		<!-- <dependency> <groupId>org.hsqldb</groupId> <artifactId>hsqldb</artifactId> 
-			</dependency> -->
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>

--- a/ssclj/jar/pom.xml
+++ b/ssclj/jar/pom.xml
@@ -121,10 +121,12 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -127,6 +127,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Downgrades hsqlsb as a test dependency to prevent this from being included in artifacts. Verify that this change does not interfere with the test workflow.