### PR TITLE
Revert "remove hsqldb as a runtime dependency" (connected to #238)

### DIFF
--- a/jar-persistence/pom.xml
+++ b/jar-persistence/pom.xml
@@ -64,7 +64,6 @@
 		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
-			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/jar-service/pom.xml
+++ b/jar-service/pom.xml
@@ -131,11 +131,15 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- <dependency> <groupId>org.hibernate</groupId> <artifactId>hibernate-entitymanager</artifactId> 
+			</dependency> -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-jdk14</artifactId>
 		</dependency>
 
+		<!-- <dependency> <groupId>org.hsqldb</groupId> <artifactId>hsqldb</artifactId> 
+			</dependency> -->
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>

--- a/ssclj/jar/pom.xml
+++ b/ssclj/jar/pom.xml
@@ -121,12 +121,10 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -127,7 +127,6 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
@st: There is a compile time dependency on the HSQLDB driver.  This must be understood and removed before this is merged back in.