### PR TITLE
upgrade version of servlet api (slipstream/SlipStream#66)

### DIFF
--- a/jar-service/pom.xml
+++ b/jar-service/pom.xml
@@ -109,8 +109,8 @@
 
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<scope>compile</scope>
+			<artifactId>javax.servlet-api</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/ssclj/jar/pom.xml
+++ b/ssclj/jar/pom.xml
@@ -76,7 +76,7 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>compojure</groupId>


### PR DESCRIPTION
Connected to slipstream/SlipStream#66. Upgrades Servlet API version and downgrades dependency to "provided".  Must be merged at the same time as PR in slipstream/Slipstream repository.