### PR TITLE
Bug/#369 sentry logging crash

### DIFF
--- a/jar-service/pom.xml
+++ b/jar-service/pom.xml
@@ -57,10 +57,12 @@
 			<artifactId>SlipStreamUI</artifactId>
 		</dependency>
 
+<!--
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
+-->
 
 		<dependency>
 			<groupId>org.clojure</groupId>
@@ -151,11 +153,13 @@
 			<type>jar</type>
 		</dependency>
 
+<!--
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>13.0</version> <!-- needed here to avoid inheriting 15.0 from raven -->
+			<version>13.0</version> 
 		</dependency>
+-->
 
 	</dependencies>
 

--- a/jar-service/pom.xml
+++ b/jar-service/pom.xml
@@ -49,20 +49,13 @@
 			<groupId>com.sixsq.slipstream</groupId>
 			<artifactId>SlipStreamConnector</artifactId>
 			<type>test-jar</type>
-            <scope>test</scope>
+                        <scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.sixsq.slipstream</groupId>
 			<artifactId>SlipStreamUI</artifactId>
 		</dependency>
-
-<!--
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-		</dependency>
--->
 
 		<dependency>
 			<groupId>org.clojure</groupId>
@@ -133,15 +126,11 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- <dependency> <groupId>org.hibernate</groupId> <artifactId>hibernate-entitymanager</artifactId> 
-			</dependency> -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-jdk14</artifactId>
 		</dependency>
 
-		<!-- <dependency> <groupId>org.hsqldb</groupId> <artifactId>hsqldb</artifactId> 
-			</dependency> -->
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
@@ -152,14 +141,6 @@
 			<artifactId>jsch</artifactId>
 			<type>jar</type>
 		</dependency>
-
-<!--
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>13.0</version> 
-		</dependency>
--->
 
 	</dependencies>
 

--- a/jar-service/pom.xml
+++ b/jar-service/pom.xml
@@ -63,11 +63,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.clojars.nathell</groupId>
-			<artifactId>tagsoup</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-entitymanager</artifactId>
 		</dependency>

--- a/rpm/pom.xml
+++ b/rpm/pom.xml
@@ -116,7 +116,6 @@
                                 <artifactItem>
                                     <groupId>com.google.guava</groupId>
                                     <artifactId>guava</artifactId>
-                                    <version>15.0</version>
                                 </artifactItem>
                                 <artifactItem>
                         			<groupId>com.fasterxml.jackson.core</groupId>

--- a/rpm/pom.xml
+++ b/rpm/pom.xml
@@ -118,8 +118,16 @@
                                     <artifactId>guava</artifactId>
                                 </artifactItem>
                                 <artifactItem>
-                        			<groupId>com.fasterxml.jackson.core</groupId>
-                        			<artifactId>jackson-databind</artifactId>
+                                  <groupId>com.fasterxml.jackson.core</groupId>
+                                  <artifactId>jackson-databind</artifactId>
+                                </artifactItem>
+                                <artifactItem>
+                                  <groupId>com.fasterxml.jackson.core</groupId>
+                                  <artifactId>jackson-core</artifactId>
+                                </artifactItem>
+                                <artifactItem>
+                                  <groupId>com.fasterxml.jackson.core</groupId>
+                                  <artifactId>jackson-annotations</artifactId>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -101,13 +101,6 @@
       <artifactId>mail</artifactId>
     </dependency>
 
-    <!-- Needs to be before junit -->
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -140,11 +140,6 @@
       <type>jar</type>
     </dependency>
 
-<!--     <dependency>
-      <groupId>net.kencochrane.raven</groupId>
-      <artifactId>raven</artifactId>
-    </dependency>
- -->
   </dependencies>
 
   <build>


### PR DESCRIPTION
This pull request reorganizes the logging dependencies to put everything into the `lib/logging` subdirectory of Jetty.  They have also been removed from the war file to avoid conflicts between versions.  The guava dependency version has also been changed to use the version in the main `pom.xml` file everywhere. 