### PR TITLE
Minor (added pre/post scale targets definitions).

### DIFF
--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Target.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Target.java
@@ -39,6 +39,8 @@ public class Target implements Serializable {
 	public static final String REPORT_TARGET = "report";
 	public static final String ONVMADD_TARGET = "onvmadd";
 	public static final String ONVMREMOVE_TARGET = "onvmremove";
+	public static final String PRESCALE_TARGET = "prescale";
+	public static final String POSTSCALE_TARGET = "postscale";
 
 	@Id
 	@GeneratedValue
@@ -91,9 +93,13 @@ public class Target implements Serializable {
 		this.script = script;
 	}
 
-
 	public Target copy() {
 		return new Target(getName(), getScript());
 	}
+
+	public static String[] getTargetScriptNames() {
+        return new String[]{EXECUTE_TARGET, REPORT_TARGET, ONVMADD_TARGET,
+				ONVMREMOVE_TARGET, PRESCALE_TARGET, POSTSCALE_TARGET};
+    }
 
 }

--- a/jar-service/src/main/java/com/sixsq/slipstream/module/ImageFormProcessor.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/module/ImageFormProcessor.java
@@ -180,7 +180,7 @@ public class ImageFormProcessor extends ModuleFormProcessor {
 
 		Set<Target> targets = new HashSet<Target>();
 
-		for (String targetName : TARGET_SCRIPT_NAMES) {
+		for (String targetName : Target.getTargetScriptNames()) {
 			addTarget(form, targets, targetName);
 		}
 

--- a/jar-service/src/main/java/com/sixsq/slipstream/module/ImageFormProcessor.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/module/ImageFormProcessor.java
@@ -39,7 +39,6 @@ import com.sixsq.slipstream.persistence.User;
 
 public class ImageFormProcessor extends ModuleFormProcessor {
 
-	public static final String[] TARGET_SCRIPT_NAMES = { "execute", "report", "onvmadd", "onvmremove" };
 	public static final String PRERECIPE_SCRIPT_NAME = "prerecipe--script";
 	public static final String MODULE_REFERENCE_NAME = "moduleReference";
 


### PR DESCRIPTION
Added definitions for pre/post scale targets persistence.

The scripts themselves will be documented as part of slipstream/SlipStreamClient#114  (this follows the same pattern as was done for OnVmAdd/Remove).

Connected to #359 