### PR TITLE
Fix #405

### DIFF
--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/resources/common/crud.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/resources/common/crud.clj
@@ -63,6 +63,19 @@
   [request]  
   (throw (u/ex-bad-method request)))
 
+
+(defn resource-name-collection-dispatch
+  [request collection]
+  (-> request
+      (get-in [:params :resource-name])
+      u/lisp-to-camelcase))
+
+(defmulti sort-collection resource-name-collection-dispatch)
+
+(defmethod sort-collection :default
+  [request collection]
+  collection)
+
 ;;
 ;; Resource schema validation.
 ;;

--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/resources/common/std_crud.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/resources/common/std_crud.clj
@@ -87,6 +87,9 @@
            ;; filtering
            (cf/cimi-filter-tree (get-in request [:cimi-params :filter]))
 
+           ;; ordering
+           (crud/sort-collection request)
+
            ;; paginating
            (pg/paginate         (get-in request [:cimi-params :first]) (get-in request [:cimi-params :last]))
 

--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/resources/event.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/resources/event.clj
@@ -1,14 +1,14 @@
 (ns 
   com.sixsq.slipstream.ssclj.resources.event
   (:require
-    [clojure.tools.logging :as log]
-    [schema.core :as s]
-    [com.sixsq.slipstream.ssclj.resources.common.authz :as a]
-    [com.sixsq.slipstream.ssclj.resources.common.crud :as crud]
-    [com.sixsq.slipstream.ssclj.resources.common.std-crud :as std-crud]
-    [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
-    [com.sixsq.slipstream.ssclj.resources.common.schema :as c]
-    [com.sixsq.slipstream.ssclj.resources.common.debug-utils :as du]))
+    [clojure.tools.logging                                    :as log]
+    [schema.core                                              :as s]
+
+    [com.sixsq.slipstream.ssclj.resources.common.authz        :as a]
+    [com.sixsq.slipstream.ssclj.resources.common.crud         :as crud]
+    [com.sixsq.slipstream.ssclj.resources.common.std-crud     :as std-crud]
+    [com.sixsq.slipstream.ssclj.resources.common.utils        :as u]
+    [com.sixsq.slipstream.ssclj.resources.common.schema       :as c]))
 
 (def ^:const resource-tag     :events)
 (def ^:const resource-name    "Event")
@@ -101,20 +101,17 @@
 ;; collection
 ;;
 
-(defn compare-timestamps-desc
-  [e1 e2]
-  (compare (:timestamp e2) (:timestamp e1)))
-
-(defn sort-by-timestamps
+(defn sort-by-timestamps-desc
   [events]
-  (sort compare-timestamps-desc events))
+  (->>  events
+        (sort-by :timestamp)
+        reverse))
 
 (defmethod crud/sort-collection resource-name
-  [request collection]
-  (sort-by-timestamps collection))
+  [request events]
+  (sort-by-timestamps-desc events))
 
 (def query-impl (std-crud/query-fn resource-name collection-acl collection-uri resource-tag))
 (defmethod crud/query resource-name
   [request]
-  (-> request
-      query-impl))
+  (query-impl request))

--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/resources/event.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/resources/event.clj
@@ -1,13 +1,14 @@
 (ns 
   com.sixsq.slipstream.ssclj.resources.event
   (:require
-    [clojure.tools.logging                                  :as log]
-    [schema.core                                            :as s]
-    [com.sixsq.slipstream.ssclj.resources.common.authz      :as a]
-    [com.sixsq.slipstream.ssclj.resources.common.crud       :as crud]
-    [com.sixsq.slipstream.ssclj.resources.common.std-crud   :as std-crud]
-    [com.sixsq.slipstream.ssclj.resources.common.utils      :as u]
-    [com.sixsq.slipstream.ssclj.resources.common.schema     :as c]))
+    [clojure.tools.logging :as log]
+    [schema.core :as s]
+    [com.sixsq.slipstream.ssclj.resources.common.authz :as a]
+    [com.sixsq.slipstream.ssclj.resources.common.crud :as crud]
+    [com.sixsq.slipstream.ssclj.resources.common.std-crud :as std-crud]
+    [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
+    [com.sixsq.slipstream.ssclj.resources.common.schema :as c]
+    [com.sixsq.slipstream.ssclj.resources.common.debug-utils :as du]))
 
 (def ^:const resource-tag     :events)
 (def ^:const resource-name    "Event")
@@ -99,7 +100,21 @@
 ;;
 ;; collection
 ;;
+
+(defn compare-timestamps-desc
+  [e1 e2]
+  (compare (:timestamp e2) (:timestamp e1)))
+
+(defn sort-by-timestamps
+  [events]
+  (sort compare-timestamps-desc events))
+
+(defmethod crud/sort-collection resource-name
+  [request collection]
+  (sort-by-timestamps collection))
+
 (def query-impl (std-crud/query-fn resource-name collection-acl collection-uri resource-tag))
 (defmethod crud/query resource-name
   [request]
-  (query-impl request))
+  (-> request
+      query-impl))

--- a/ssclj/jar/src/test/clojure/com/sixsq/slipstream/ssclj/resources/test_utils.clj
+++ b/ssclj/jar/src/test/clojure/com/sixsq/slipstream/ssclj/resources/test_utils.clj
@@ -15,7 +15,9 @@
     [com.sixsq.slipstream.ssclj.resources.lifecycle-test-utils :as t]
     [peridot.core :refer :all]
     [schema.core :as sc]
-    [clojure.data.json :as json]))
+    [clojure.data.json :as json]
+    [com.sixsq.slipstream.ssclj.usage.utils :as u]
+    [clj-time.core :as time]))
 
 (defn- urlencode-param
   [p]
@@ -95,3 +97,10 @@
   [resources schema]
   (doseq [resource resources]
     (is-valid? resource schema)))
+
+(def not-before? (complement time/before?))
+
+(defn ordered-desc?
+  [timestamps]
+  (every? (fn [[a b]] (not-before? (u/to-time a) (u/to-time b))) (partition 2 1 timestamps)))
+

--- a/ssclj/jar/src/test/clojure/com/sixsq/slipstream/ssclj/resources/usage_test.clj
+++ b/ssclj/jar/src/test/clojure/com/sixsq/slipstream/ssclj/resources/usage_test.clj
@@ -51,15 +51,11 @@
 
 (def base-uri (str p/service-context (cu/de-camelcase resource-name)))
 
-(defn every-timestamps?
-  [pred? ts]
-  (every? (fn [[a b]] (pred? (u/to-time a) (u/to-time b))) (partition 2 1 ts)))
-
 (defn are-desc-dates?
   [m]
   (->> (get-in m [:response :body :usages])
        (map :end_timestamp)
-       (every-timestamps? (complement time/before?))
+       tu/ordered-desc?
        is)
   m)
 


### PR DESCRIPTION
The collection (result of query) is ordered specifically by each
resource, just before pagination.
(default ordering is to simply return the collection).
Event collection sorts the collection by :timestamp desc.