### PR TITLE
Improve logic to avoid useless closing of usage record.

### DIFF
--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/Collector.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/Collector.java
@@ -225,14 +225,10 @@ public class Collector {
 
 			String instanceId = cloudVm.getInstanceId();
 
-			if (cloudVm.getIsUsable() && !UsageRecorder.hasRecorded(cloud, instanceId)) {
-				logger.info("VM usable => start records all metrics");
+			if (cloudVm.getIsUsable()) {
 				UsageRecorder.insertStart(instanceId, user, cloud, UsageRecorder.createVmMetrics(cloudVm));
-			} else if (!cloudVm.getIsUsable() && UsageRecorder.hasRecorded(cloud, instanceId)) {
-				logger.info("VM becomes unusable => stop all metrics");
-				UsageRecorder.insertEnd(instanceId, user, cloud, UsageRecorder.createVmMetrics(cloudVm));
 			} else {
-				logger.info(instanceId + " already recorded");
+				UsageRecorder.insertEnd(instanceId, user, cloud, UsageRecorder.createVmMetrics(cloudVm));
 			}
 		}
 	}

--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/usage/record_keeper.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/usage/record_keeper.clj
@@ -136,7 +136,8 @@
         usage_records
         (kc/set-fields {:end_timestamp close-timestamp})
         (kc/where {:cloud_vm_instanceid (:cloud_vm_instanceid usage-metric)
-                   :metric_name         (:metric_name usage-metric)})))
+                   :metric_name         (:metric_name usage-metric)
+                   :end_timestamp       nil})))
 
   ([usage-metric]
     (close-usage-record usage-metric (:end_timestamp usage-metric))))


### PR DESCRIPTION
When VM becomes unusable, corresponding metrics are closed.
10 seconds later, this VM is seen as gone, and we do not need to
re-close those metrics.
Change done:
* insertStart and insertEnd methods now take care of using hasRecorded to avoid useless messages.