### PR TITLE
Fix: long abort messages generates 500

### DIFF
--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/RuntimeParameter.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/RuntimeParameter.java
@@ -234,6 +234,8 @@ public class RuntimeParameter extends Metadata {
 		return nodeName + RuntimeParameter.NODE_MULTIPLICITY_INDEX_SEPARATOR + nodeInstanceId;
 	}
 
+	public static final int VALUE_MAX_LENGTH = 4096;
+
 	@Id
 	private String resourceUri;
 
@@ -241,7 +243,7 @@ public class RuntimeParameter extends Metadata {
 	private String key_;
 
 	@Text(required = false, data = true)
-	@Column(length = 4096)
+	@Column(length = VALUE_MAX_LENGTH)
 	private String value = "";
 
 	@Attribute

--- a/jar-service/src/main/java/com/sixsq/slipstream/run/RuntimeParameterResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/run/RuntimeParameterResource.java
@@ -124,6 +124,14 @@ public class RuntimeParameterResource extends RunBaseResource {
 		return runtimeParameter.getValue();
 	}
 
+	private String truncateMiddle(int maxLength, String text, String truncateMessage) {
+		if (text != null && text.length() > maxLength) {
+			int partsize = (maxLength - truncateMessage.length()) / 2;
+			text = text.substring(0, partsize-1) + truncateMessage + text.substring(text.length() - partsize);
+		}
+		return text;
+	}
+
 	@Put
 	public void update(Representation entity) throws ResourceException,
 			NotFoundException, ValidationException {
@@ -142,6 +150,7 @@ public class RuntimeParameterResource extends RunBaseResource {
 
 		if (isGlobalAbort || isNodeAbort) {
 			if (!runtimeParameter.isSet()) {
+				value = truncateMiddle(RuntimeParameter.VALUE_MAX_LENGTH, value, "\n(truncated)\n");
 				abortOrReset(value, em);
 				setValue(value);
 			}
@@ -158,6 +167,10 @@ public class RuntimeParameterResource extends RunBaseResource {
 	}
 
 	private void setValue(String value) {
+		if (value != null && value.length() > RuntimeParameter.VALUE_MAX_LENGTH) {
+			throwClientBadRequest("Value too long (" + value.length() + "). " +
+					"Maximum length allowed: " + RuntimeParameter.VALUE_MAX_LENGTH + ".");
+		}
 		runtimeParameter.setValue(value);
 		RuntimeParameterMediator.processSpecialValue(runtimeParameter);
 	}
@@ -211,10 +224,7 @@ public class RuntimeParameterResource extends RunBaseResource {
 			sm = StateMachine.createStateMachine(run);
 			try {
 				sm.tryAdvanceToProvisionning();
-			} catch (InvalidStateException e) {
-				e.printStackTrace();
-				throwClientBadRequest(String.format("Failed to advance state %s: %s", fromToState, e.getMessage()));
-			} catch (CannotAdvanceFromTerminalStateException e) {
+			} catch (InvalidStateException | CannotAdvanceFromTerminalStateException e) {
 				e.printStackTrace();
 				throwClientBadRequest(String.format("Failed to advance state %s: %s", fromToState, e.getMessage()));
 			}
@@ -252,15 +262,8 @@ public class RuntimeParameterResource extends RunBaseResource {
 		States state;
 		try {
 			state = sc.updateState(nodeName);
-		} catch (CannotAdvanceFromTerminalStateException e) {
-			throw new ResourceException(Status.CLIENT_ERROR_CONFLICT,
-					e.getMessage());
-		} catch (InvalidStateException e) {
-			throw new ResourceException(Status.CLIENT_ERROR_CONFLICT,
-					e.getMessage());
-		} catch (SlipStreamClientException e) {
-			throw new ResourceException(Status.CLIENT_ERROR_CONFLICT,
-					e.getMessage());
+		} catch (InvalidStateException | SlipStreamClientException e) {
+			throw new ResourceException(Status.CLIENT_ERROR_CONFLICT, e.getMessage());
 		}
 		return state;
 	}


### PR DESCRIPTION
If the value of a runtime parameter is too big for the DB it will be truncated if it's an abort message or a proper error message will be raised. 

Connected to #483