### PR TITLE
reduce async logging levels

### DIFF
--- a/jar-async/src/slipstream/async/collector.clj
+++ b/jar-async/src/slipstream/async/collector.clj
@@ -99,11 +99,11 @@
 
 (defn log-timeout
   [user connector elapsed]
-  (log/log-error (build-msg user connector elapsed "Timed out in waiting for collecting vms")))
+  (log/log-error (build-msg user connector elapsed "Timed out when waiting for collecting vms")))
 
 (defn log-failure
   [user connector elapsed]
-  (log/log-error (build-msg user connector elapsed "Failed collecting vms")))
+  (log/log-error (build-msg user connector elapsed "Failed collecting VMs")))
 
 (defn log-collected
   [user connector elapsed v]
@@ -120,7 +120,7 @@
       (let [res (alts! [ch (timeout timeout-collect)])]
         (if (nil? res)
           (log/log-error  "Timeout updating metrics for user "  (get-name user))
-          (log/log-info   "Executed update-metric request for " (get-name user)))))
+          (log/log-debug   "Executed update metric request for " (get-name user)))))
     (go (>! ch (updator/update-metric user connector)))))
 
 (defn collect!
@@ -144,7 +144,7 @@
 ; Start collector readers
 (defn collect-readers
   [chan]
-  (log/log-info "Starting " number-of-readers " collector readers...")
+  (log/log-debug "Starting " number-of-readers " collector readers...")
   (doseq [i (range number-of-readers)]
     (go
       (while true
@@ -179,7 +179,7 @@
 
 (defn inform-nothing-to-do 
   [context]
-  (log/log-info context ": no users to collect."))
+  (log/log-debug context ": no users to collect."))
 
 (defn show-current-channel-usage   
   [context]

--- a/jar-async/src/slipstream/async/garbage_collector.clj
+++ b/jar-async/src/slipstream/async/garbage_collector.clj
@@ -31,7 +31,7 @@
         (if (nil? no-of-purged)
           (log/log-error
             "Timeout garbage collecting runs")
-          (log/log-info
+          (log/log-debug
             (str "Purged " no-of-purged " runs")))))
     (go (>! ch (purge)))))
 
@@ -40,7 +40,7 @@
 ; Start collector readers
 (defn collect-readers
   []
-  (log/log-info "Starting " number-of-readers " garbage collector readers...")
+  (log/log-debug "Starting " number-of-readers " garbage collector readers...")
   (doseq [i (range number-of-readers)]
     (go
       (while true

--- a/jar-async/src/slipstream/async/launcher.clj
+++ b/jar-async/src/slipstream/async/launcher.clj
@@ -40,25 +40,25 @@
     (go
       (let [[v c] (alts! [ch (timeout timeout-launch)])]
         (if (nil? v)
-          (do
-            (log/log-error "Oops... timeout")
+          (let [msg (str "Timeout launching run " (.getUuid run))]
+            (log/log-error msg)
             (swap! errors inc)
-            (Run/abort "Timeout launching run" (.getUuid run)))
-          (do
-            (log/log-info "Launched!")
+            (Run/abort msg)
+          (let [msg (str "Launched run " (.getUuid run))]
+            (log/log-info msg)
             (swap! completed inc)))))
     (go (>! ch (Launcher/launch run user)))))
 
 ; Start launch readers
 (defn launch-readers
   []
-  (log/log-info "Starting " number-of-readers " readers...")
+  (log/log-debug "Starting " number-of-readers " readers...")
   (doseq [i (range number-of-readers)]
     (go
       (while true
         (let [[[run user] ch] (alts! [launcher-chan (timeout timeout-processing-loop)])]
           (if (nil? run)
-            (log/log-info "Launch reader " i " loop idle. Looping...")
+            (log/log-debug "Launch reader " i " loop idle. Looping...")
             (try
               (launch! run user)
               (catch Exception e (log/log-error "caught exception: " (.getMessage e))))))))))


### PR DESCRIPTION
The SlipStream logs contain too much information for effective debugging of problems.  Much of this comes from repetitive information in the async processing.  This pull request reduces many of the logging level to debug, so that much of the information is not logged at the default info logging level. 