### PR TITLE
allow metrics to be pushed to graphite

### DIFF
--- a/ssclj/jar/pom.xml
+++ b/ssclj/jar/pom.xml
@@ -112,6 +112,10 @@
       <artifactId>metrics-clojure-jvm</artifactId>
     </dependency>
     <dependency>
+      <groupId>metrics-clojure-graphite</groupId>
+      <artifactId>metrics-clojure-graphite</artifactId>
+    </dependency>
+    <dependency>
       <groupId>fs</groupId>
       <artifactId>fs</artifactId>
     </dependency>

--- a/ssclj/jar/project.clj
+++ b/ssclj/jar/project.clj
@@ -22,6 +22,8 @@
                  [metrics-clojure-ring/metrics-clojure-ring "2.5.1"
                    :exclusions [[cheshire/cheshire]] ]
                  [metrics-clojure-jvm/metrics-clojure-jvm   "2.5.1"]
+                 [metrics-clojure-graphite/metrics-clojure-graphite   "2.5.1"]
+
                  [fs/fs                                     "1.3.3"]
                  [org.slf4j/slf4j-log4j12                   "1.7.12"]
                  [instaparse                                "1.4.1"]

--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/app/graphite.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/app/graphite.clj
@@ -15,6 +15,8 @@
                       :duration-unit TimeUnit/MILLISECONDS
                       :filter MetricFilter/ALL}))
 
+;; TODO: add a stop function for clean shutdown
+
 (defn start-graphite-reporter
   []
   (if-let [host (env :graphite-host)]

--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/app/graphite.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/app/graphite.clj
@@ -1,0 +1,28 @@
+(ns com.sixsq.slipstream.ssclj.app.graphite
+  (:require
+   [clojure.tools.logging :as log]
+   [metrics.reporters.graphite :as graphite]
+   [environ.core :refer [env]])
+  (:import
+   [java.util.concurrent TimeUnit]
+   [com.codahale.metrics MetricFilter]))
+
+(defn create-reporter
+  [host]
+  (graphite/reporter {:host host
+                      :prefix "slipstream"
+                      :rate-unit TimeUnit/SECONDS
+                      :duration-unit TimeUnit/MILLISECONDS
+                      :filter MetricFilter/ALL}))
+
+(defn start-graphite-reporter
+  []
+  (if-let [host (env :graphite-host)]
+    (try 
+      (-> host
+          (create-reporter)
+          (graphite/start 10))
+      (log/info "graphite metrics reporter started for" host)
+      (catch Exception e
+        (log/error "graphite metrics reporter error:" (.getMessage e))))
+    (log/info "graphite metrics reporter NOT started")))

--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/app/server.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/app/server.clj
@@ -76,12 +76,11 @@
    (log/info "java classpath: " (System/getProperty "java.class.path"))
    (set-db-impl)
    (resources/initialize)
-   (if (= impl "httpkit")
-     (-> (create-ring-handler)
-         (httpkit/start-container port))
-     (-> (create-ring-handler)
-         (aleph/start-container port)))
-   (graphite/start-graphite-reporter)))
+   (let [handler (create-ring-handler)]
+     (graphite/start-graphite-reporter)
+     (if (= impl "httpkit")
+       (httpkit/start-container handler port)
+       (aleph/start-container handler port)))))
 
 (defn stop
   "Stops the application server by calling the function that was

--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/app/server.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/app/server.clj
@@ -21,6 +21,7 @@
     [com.sixsq.slipstream.ssclj.middleware.cimi-params :refer [wrap-cimi-params]]
     [com.sixsq.slipstream.ssclj.app.routes :as routes]
     [com.sixsq.slipstream.ssclj.app.params :as p]
+    [com.sixsq.slipstream.ssclj.app.graphite :as graphite]
     [com.sixsq.slipstream.ssclj.db.impl :as db]
     [com.sixsq.slipstream.ssclj.db.database-binding :as dbdb]
     [com.sixsq.slipstream.ssclj.resources.common.dynamic-load :as resources]
@@ -79,7 +80,8 @@
      (-> (create-ring-handler)
          (httpkit/start-container port))
      (-> (create-ring-handler)
-         (aleph/start-container port)))))
+         (aleph/start-container port)))
+   (graphite/start-graphite-reporter)))
 
 (defn stop
   "Stops the application server by calling the function that was

--- a/ssclj/rpm/src/main/resources/etc-default-ssclj
+++ b/ssclj/rpm/src/main/resources/etc-default-ssclj
@@ -1,3 +1,4 @@
 # Defaults for the SlipStream API server.
 #SSCLJ_PORT=8201
+#SSCLJ_GRAPHITE_HOST=127.0.0.1
 export JAVA=/etc/alternatives/jre_${server.jre.version}/bin/java

--- a/ssclj/rpm/src/main/scripts/ssclj
+++ b/ssclj/rpm/src/main/scripts/ssclj
@@ -165,6 +165,15 @@ fi
 
 
 #####################################################
+# See if SSCLJ_GRAPHITE_HOST is defined
+#####################################################
+GRAPHITE_OPTION=''
+if [ -n "$SSCLJ_GRAPHITE_HOST" ]; then
+  GRAPHITE_OPTION="-Dgraphite.host=${SSCLJ_GRAPHITE_HOST}"
+fi
+
+
+#####################################################
 # Define the command for starting the service
 #####################################################
 SSCLJ_JAR=$SSCLJ_HOME/lib/ssclj.jar
@@ -173,7 +182,7 @@ if [ ! -f "$SSCLJ_JAR" ]; then
   exit 1
 fi
 
-RUN_ARGS=(${JAVA_OPTIONS[@]} -Dconfig.path=db.spec -Dlogfile.path=production -cp "$SSCLJ_HOME/resources:$SSCLJ_JAR" $SSCLJ_CLASS $SSCLJ_PORT)
+RUN_ARGS=(${JAVA_OPTIONS[@]} ${GRAPHITE_OPTION} -Dconfig.path=db.spec -Dlogfile.path=production -cp "$SSCLJ_HOME/resources:$SSCLJ_JAR" $SSCLJ_CLASS $SSCLJ_PORT)
 RUN_CMD=("$JAVA" ${RUN_ARGS[@]})
 
 


### PR DESCRIPTION
This PR allows a graphite server to be specified on startup.  If specified, then the defined metrics (JVM, Ring, etc.) will be pushed to that server.  If not specified, then the thread to push the metrics is not started. In both cases, the metrics will continue to be available from `/api/metrics` in JSON format.