### PR TITLE
Configured SSCLJ to log metrics on the local graphite stack.

### DIFF
--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/app/graphite.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/app/graphite.clj
@@ -10,7 +10,7 @@
 (defn create-reporter
   [host]
   (graphite/reporter {:host host
-                      :prefix "slipstream"
+                      :prefix "ssclj"
                       :rate-unit TimeUnit/SECONDS
                       :duration-unit TimeUnit/MILLISECONDS
                       :filter MetricFilter/ALL}))

--- a/ssclj/rpm/src/main/resources/etc-default-ssclj
+++ b/ssclj/rpm/src/main/resources/etc-default-ssclj
@@ -1,4 +1,4 @@
 # Defaults for the SlipStream API server.
 #SSCLJ_PORT=8201
-#SSCLJ_GRAPHITE_HOST=127.0.0.1
+SSCLJ_GRAPHITE_HOST=127.0.0.1
 export JAVA=/etc/alternatives/jre_${server.jre.version}/bin/java


### PR DESCRIPTION
Connected to SixSq/tasklist#497