### PR TITLE
Fix: no longer rely on static state to avoid closing record

### DIFF
--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/UsageRecorder.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/UsageRecorder.java
@@ -75,9 +75,8 @@ public class UsageRecorder {
 			}
 
 			if(!hasRecorded(cloud, instanceId)){
-				logger.fine("Not recorded => avoiding inserting usage record END for "
+				logger.fine("Not recorded but still inserting usage record END for "
 						+ metrics + ", " + describe(instanceId, user, cloud));
-				return;
 			}
 
 			logger.info("Inserting usage record END, metrics" + metrics + ", for " + describe(instanceId, user, cloud));

--- a/ssclj/jar/project.clj
+++ b/ssclj/jar/project.clj
@@ -1,4 +1,4 @@
-(defproject com.sixsq.slipstream/ssclj "2.19.1-SNAPSHOT"
+(defproject com.sixsq.slipstream/ssclj "2.19.2-SNAPSHOT"
   :description    "Clojure REST resources"
   :url            "http://sixsq.com"
   :license {:name "Apache License, Version 2.0"
@@ -28,7 +28,7 @@
                  [org.slf4j/slf4j-log4j12                   "1.7.13"]
                  [instaparse                                "1.4.1"]
                 ; ;; Authentication service
-                 [com.sixsq.slipstream/auth                 "2.19.1-SNAPSHOT"]
+                 [com.sixsq.slipstream/auth                 "2.19.2-SNAPSHOT"]
                 ; ;; Environment settings
                  [environ                                   "1.0.1"]
                 ; ;; database

--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/usage/record_keeper.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/usage/record_keeper.clj
@@ -120,9 +120,9 @@
 ;;
 ;; actions
 ;;
-(defn- log-severe-wrong-transition  
+(defn- log-wrong-transition
   [state action]
-  (log/fatal "Action" action " is not allowed for state " state))
+  (log/info "Action" action " is not allowed for state " state))
 
 (defn- insert-metric
   [usage-metric]
@@ -155,7 +155,7 @@
   (let [current-state (state usage-metric)]
     (case (sm/action current-state trigger)      
       :insert-start             (insert-metric                usage-metric)
-      :severe-wrong-transition  (log-severe-wrong-transition  current-state trigger)
+      :wrong-transition         (log-wrong-transition  current-state trigger)
       :close-record             (close-usage-record           usage-metric))))
 
 (defn -insertStart

--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/usage/state_machine.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/usage/state_machine.clj
@@ -8,13 +8,13 @@
 ;; 
 (def ^:private state-transitions
   { :initial  { :start  :insert-start            
-                :stop   :severe-wrong-transition}
+                :stop   :wrong-transition}
 
-    :started  { :start  :severe-wrong-transition 
+    :started  { :start  :wrong-transition
                 :stop   :close-record}
 
     :stopped  { :start  :insert-start
-                :stop   :severe-wrong-transition}})
+                :stop   :wrong-transition}})
 
 (defn action
   [state trigger]

--- a/ssclj/jar/src/test/clojure/com/sixsq/slipstream/ssclj/usage/state_machine_test.clj
+++ b/ssclj/jar/src/test/clojure/com/sixsq/slipstream/ssclj/usage/state_machine_test.clj
@@ -9,10 +9,10 @@
 
 (deftest transitions
   (leads-to :initial :start :insert-start)
-  (leads-to :initial :stop  :severe-wrong-transition)
+  (leads-to :initial :stop  :wrong-transition)
 
-  (leads-to :started :start :severe-wrong-transition)
+  (leads-to :started :start :wrong-transition)
   (leads-to :started :stop  :close-record)
 
   (leads-to :stopped :start :insert-start)
-  (leads-to :stopped :stop  :severe-wrong-transition))
+  (leads-to :stopped :stop  :wrong-transition))


### PR DESCRIPTION
Log levels in case of inconsistent transitions lowered down.
Connected to #554 