### PR TITLE
New activeOnly query request parameter

### DIFF
--- a/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunView.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunView.java
@@ -92,22 +92,22 @@ public class RunView {
 
 	public static List<RunView> fetchListView(User user, int offset, int limit)
 			throws ConfigurationException, ValidationException {
-		return fetchListView(user, null, offset, limit, null);
+		return fetchListView(user, null, offset, limit, null, false);
 	}
 
 	public static List<RunView> fetchListView(User user, String moduleResourceUri, int offset, int limit,
-			String cloudServiceName) throws ConfigurationException, ValidationException {
-		return Run.viewList(user, moduleResourceUri, offset, limit, cloudServiceName);
+			String cloudServiceName, boolean activeOnly) throws ConfigurationException, ValidationException {
+		return Run.viewList(user, moduleResourceUri, offset, limit, cloudServiceName, activeOnly);
 	}
 
 	public static int fetchListViewCount(User user)
 			throws ConfigurationException, ValidationException {
-		return fetchListViewCount(user, null, null);
+		return fetchListViewCount(user, null, null, false);
 	}
 
-	public static int fetchListViewCount(User user, String moduleResourceUri, String cloudServiceName)
+	public static int fetchListViewCount(User user, String moduleResourceUri, String cloudServiceName, boolean activeOnly)
 			throws ConfigurationException, ValidationException {
-		return Run.viewListCount(user, moduleResourceUri, cloudServiceName);
+		return Run.viewListCount(user, moduleResourceUri, cloudServiceName, activeOnly);
 	}
 
 	public RunView copy() {

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunViewList.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/run/RunViewList.java
@@ -60,28 +60,28 @@ public class RunViewList {
 		return runs;
 	}
 
-	public void populate(User user, int offset, int limit, String cloudServiceName) throws ConfigurationException, ValidationException {
-		populate(user, null, offset, limit, cloudServiceName);
+	public void populate(User user, int offset, int limit, String cloudServiceName, boolean activeOnly) throws ConfigurationException, ValidationException {
+		populate(user, null, offset, limit, cloudServiceName, activeOnly);
 	}
 
-	public void populate(User user, String moduleResourceUri, int offset, int limit) throws ConfigurationException, ValidationException {
-		populate(user, moduleResourceUri, offset, limit, null);
+	public void populate(User user, String moduleResourceUri, int offset, int limit, boolean activeOnly) throws ConfigurationException, ValidationException {
+		populate(user, moduleResourceUri, offset, limit, null, activeOnly);
 	}
 
-	public void populate(User user, String moduleResourceUri, int offset, int limit, String cloudServiceName)
+	public void populate(User user, String moduleResourceUri, int offset, int limit, String cloudServiceName, boolean activeOnly)
 			throws ConfigurationException, ValidationException {
 		user.validate();
-		populateRuns(user, moduleResourceUri, offset, limit, cloudServiceName);
+		populateRuns(user, moduleResourceUri, offset, limit, cloudServiceName, activeOnly);
 	}
 
-	private void populateRuns(User user, String moduleResourceUri, int offset, int limit, String cloudServiceName)
+	private void populateRuns(User user, String moduleResourceUri, int offset, int limit, String cloudServiceName, boolean activeOnly)
 			throws ConfigurationException, ValidationException {
 		this.offset = offset;
 		this.limit = limit;
 		this.cloud = cloudServiceName;
 
-		totalCount = RunView.fetchListViewCount(user, moduleResourceUri, cloudServiceName);
-		runs = RunView.fetchListView(user, moduleResourceUri, offset, limit, cloudServiceName);
+		totalCount = RunView.fetchListViewCount(user, moduleResourceUri, cloudServiceName, activeOnly);
+		runs = RunView.fetchListView(user, moduleResourceUri, offset, limit, cloudServiceName, activeOnly);
 		count = runs.size();
 	}
 

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/statemachine/States.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/statemachine/States.java
@@ -2,6 +2,9 @@ package com.sixsq.slipstream.statemachine;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 /*
  * +=================================================================+
@@ -40,6 +43,12 @@ public enum States {
     						 States.Aborted,
     						 States.Unknown,
     						 States.Done);
+    }
+
+    public static List<States> active() {
+        Set<States> states = new HashSet<States>(Arrays.asList(States.values()));
+        states.removeAll(completed());
+        return new ArrayList<States>(states);
     }
 
     public static List<States> transition() {

--- a/jar-service/src/main/java/com/sixsq/slipstream/dashboard/Dashboard.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/dashboard/Dashboard.java
@@ -80,7 +80,7 @@ public class Dashboard {
 	@ElementList
 	private transient List<UsageElement> usage = new ArrayList<UsageElement>();
 
-	public void populate(User user, int offset, int limit, String cloudServiceName) throws SlipStreamException {
+	public void populate(User user, int offset, int limit, String cloudServiceName, boolean activeOnly) throws SlipStreamException {
 
 		user = User.loadByName(user.getName());  // ensure user is loaded from database
 
@@ -95,12 +95,12 @@ public class Dashboard {
 			usage.add(new UsageElement(cloud, quota, currentUsage));
 		}
 
-		runs = getRuns(user, offset, limit, cloudServiceName);
+		runs = getRuns(user, offset, limit, cloudServiceName, activeOnly);
 	}
 
-	private RunViewList getRuns(User user, int offset, int limit, String cloudServiceName) throws ConfigurationException, ValidationException{
+	private RunViewList getRuns(User user, int offset, int limit, String cloudServiceName, boolean activeOnly) throws ConfigurationException, ValidationException{
 		RunViewList runViewList = new RunViewList();
-		runViewList.populate(user, offset, limit, cloudServiceName);
+		runViewList.populate(user, offset, limit, cloudServiceName, activeOnly);
 		return runViewList;
 	}
 

--- a/jar-service/src/main/java/com/sixsq/slipstream/dashboard/DashboardResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/dashboard/DashboardResource.java
@@ -68,7 +68,7 @@ public class DashboardResource extends BaseResource {
 
 		Dashboard dashboard = new Dashboard();
 		try {
-			dashboard.populate(getUser(), getOffset(), getLimit(), getCloud());
+			dashboard.populate(getUser(), getOffset(), getLimit(), getCloud(), getActiveOnly());
 		} catch (SlipStreamClientException e) {
 			throwClientConflicError(e.getMessage());
 		} catch (SlipStreamException e) {

--- a/jar-service/src/main/java/com/sixsq/slipstream/module/ModuleResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/module/ModuleResource.java
@@ -651,7 +651,7 @@ public class ModuleResource extends ParameterizedResource<Module> {
 		Module module = getParameterized();
 		// Add runs for this specific module version (will not apply to project)
 		RunViewList runs = new RunViewList();
-		runs.populate(getUser(), module.getResourceUri(), 0, Run.DEFAULT_LIMIT);
+		runs.populate(getUser(), module.getResourceUri(), 0, Run.DEFAULT_LIMIT, getActiveOnly());
 		module.setRuns(runs);
 		return module;
 	}

--- a/jar-service/src/main/java/com/sixsq/slipstream/resource/BaseResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/resource/BaseResource.java
@@ -50,6 +50,7 @@ public abstract class BaseResource extends ServerResource {
 	public static final String USER_KEY = "user";
 	public static final String EDIT_KEY = "edit";
 	public static final String NEW_KEY = "new";
+	public static final String ACTIVE_ONLY_KEY = "activeOnly";
 
 	public static final int LIMIT_DEFAULT = 20;
 	public static final int LIMIT_MAX = 500;
@@ -220,7 +221,7 @@ public abstract class BaseResource extends ServerResource {
 			return false;
 		}
 		String trimmed = value.trim().toLowerCase();
-		return ("true".equals(trimmed) || "yes".equals(trimmed) || "on".equals(trimmed));
+		return ("true".equals(trimmed) || "yes".equals(trimmed) || "on".equals(trimmed) || "1".equals(trimmed));
 	}
 
 	private boolean isSetInQuery(String key) {
@@ -306,5 +307,9 @@ public abstract class BaseResource extends ServerResource {
 			throwClientForbiddenError("You don't have the permission to use the query parameter 'user'");
 		}
 		return user;
+	}
+
+	protected boolean getActiveOnly() {
+		return isTrue(RequestUtil.getActiveOnly(getRequest()));
 	}
 }

--- a/jar-service/src/main/java/com/sixsq/slipstream/run/RunListResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/run/RunListResource.java
@@ -124,7 +124,7 @@ public class RunListResource extends BaseResource {
 
 		RunViewList list = new RunViewList();
 		try {
-			list.populate(getUser(), getModuleResourceUri(), getOffset(), limit, getCloud());
+			list.populate(getUser(), getModuleResourceUri(), getOffset(), limit, getCloud(), getActiveOnly());
 		} catch (ConfigurationException e) {
 			throwConfigurationException(e);
 		} catch (ValidationException e) {

--- a/jar-service/src/main/java/com/sixsq/slipstream/util/RequestUtil.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/util/RequestUtil.java
@@ -211,4 +211,8 @@ public class RequestUtil {
 		return getQueryValue(request, BaseResource.CIMI_FILTER_KEY);
 	}
 
+	public static String getActiveOnly(Request request) {
+		return getQueryValue(request, BaseResource.ACTIVE_ONLY_KEY);
+	}
+
 }


### PR DESCRIPTION
Used for filtering runs to return all or only active ones. (Both cases the returned set is a subject to other request parameters.)

If the value is one of `true || yes || on || 1` (case insensitive) - then, only active runs (as defined in `States.active()` -- i.e. not `completed`) are returned.  Otherwise, all runs are returned. 

Connected to #573 

NB! Here is the bug https://github.com/slipstream/SlipStreamUI/issues/518 on UI side that doesn't allow to display inactive runs in case user has no active ones.