### PR TITLE
Improve external login name

### DIFF
--- a/auth/src/com/sixsq/slipstream/auth/cyclone.clj
+++ b/auth/src/com/sixsq/slipstream/auth/cyclone.clj
@@ -28,6 +28,12 @@
   (log/info "Cyclone authentication.")
   (uh/response-redirect (cyclone-code-url)))
 
+(defn- login-name
+  [claims]
+  (if-let [name (:name claims)]
+    (ex/sanitize-login-name name)
+    (ex/sanitize-login-name (:preferred_username claims))))
+
 (defn callback-cyclone
   [request redirect-server]
   (try
@@ -44,7 +50,7 @@
                            :access_token)
           claims          (sg/unsign-claims access-token "cyclone_pubkey.pem")]
       (log/debug "Cyclone claims " claims)
-      (ex/redirect-with-matched-user :cyclone (:preferred_username claims) (:email claims) redirect-server))
+      (ex/redirect-with-matched-user :cyclone (login-name claims) (:email claims) redirect-server))
     (catch Exception e
       (log/error "Invalid Cyclone authentication " e)
       (uh/response-redirect (str redirect-server "/dashboard")))))

--- a/auth/src/com/sixsq/slipstream/auth/external.clj
+++ b/auth/src/com/sixsq/slipstream/auth/external.clj
@@ -1,5 +1,6 @@
 (ns com.sixsq.slipstream.auth.external
   (:require [clojure.tools.logging :as log]
+            [superstring.core :as s]
             [com.sixsq.slipstream.auth.utils.db :as db]
             [com.sixsq.slipstream.auth.sign :as sg]
             [com.sixsq.slipstream.auth.utils.http :as uh]))
@@ -40,3 +41,8 @@
           (assoc :cookies {"com.sixsq.slipstream.cookie" {:value {:token token}
                                                           :path  "/"}})))
     (uh/response-redirect (str redirect-server "/login?flash-now-warning=auth-failed"))))
+
+(defn sanitize-login-name
+  "Replace characters not satisfying [a-zA-Z0-9_] with underscore"
+  [s]
+  (s/replace s #"[^a-zA-Z0-9_]" "_"))

--- a/auth/src/com/sixsq/slipstream/auth/github.clj
+++ b/auth/src/com/sixsq/slipstream/auth/github.clj
@@ -57,7 +57,7 @@
       (log/debug "Github user-info " user-info)
 
       (ex/redirect-with-matched-user :github
-                                     (:login user-info)
+                                     (-> user-info :login ex/sanitize-login-name)
                                      (retrieve-email user-info access-token)
                                      redirect-server))
 

--- a/auth/test/com/sixsq/slipstream/auth/external_test.clj
+++ b/auth/test/com/sixsq/slipstream/auth/external_test.clj
@@ -63,3 +63,8 @@
 
     (match-external-user! :cyclone "st" "st@sixsq.com")
     (is (= [(assoc user :CYCLONELOGIN "st")] (kc/select db/users)))))
+
+(deftest test-sanitize-login-name
+  (is (= "st"           (sanitize-login-name "st")))
+  (is (= "Paul_Newman"  (sanitize-login-name "Paul Newman")))
+  (is (= "abc_def_123"  (sanitize-login-name "abc-def-123"))))


### PR DESCRIPTION
* Sanitize external login name
* Use name, if available, instead of preferred_username for Cyclone

Connected to #466 