### PR TITLE
Fix: remove useless de-camelcase

### DIFF
--- a/ssclj/jar/project.clj
+++ b/ssclj/jar/project.clj
@@ -1,4 +1,4 @@
-(defproject com.sixsq.slipstream/ssclj "2.22-SNAPSHOT"
+(defproject com.sixsq.slipstream/ssclj "2.24-SNAPSHOT"
   :description    "Clojure REST resources"
   :url            "http://sixsq.com"
   :license {:name "Apache License, Version 2.0"
@@ -29,7 +29,7 @@
                  [org.slf4j/slf4j-log4j12                   "1.7.13"]
                  [instaparse                                "1.4.1"]
                 ; ;; Authentication service
-                 [com.sixsq.slipstream/auth                 "2.22-SNAPSHOT"]
+                 [com.sixsq.slipstream/auth                 "2.24-SNAPSHOT"]
                 ; ;; Environment settings
                  [environ                                   "1.0.1"]
                 ; ;; database
@@ -89,18 +89,18 @@
 
    :uberjar
      { :aot [#"com.sixsq.slipstream.ssclj.api.acl*"]
-       :env {  :clj-env        :production
+       :env {  :clj-env        "production"
                :config-path    "config-hsqldb-mem.edn"}
        :jvm-opts ["-Dlogfile.path=production"]}
 
    :dev
-     { :env {  :clj-env        :development
-               :config-path    "config-hsqldb.edn"}
+     { :env {  :clj-env        "development"
+               :config-path    "config-hsqldb-mem.edn"}
        :jvm-opts ["-Dlogfile.path=development"]
        :dependencies [ [peridot/peridot "0.4.1"]
                        [expectations/expectations "2.1.4"]]}
    :test
-     { :env {  :clj-env        :test
+     { :env {  :clj-env        "test"
                :config-path    "config-hsqldb-mem.edn"}
 
        :jvm-opts ["-Dlogfile.path=test"]

--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/resources/common/std_crud.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/resources/common/std_crud.clj
@@ -23,7 +23,7 @@
       resource-name
       (-> body
           u/strip-service-attrs
-          (crud/new-identifier (u/de-camelcase resource-name))
+          (crud/new-identifier resource-name)
           (assoc :resourceURI resource-uri)
           u/update-timestamps
           (crud/add-acl request)


### PR DESCRIPTION
Bug (same id can be added multiple times) is hidden as no resource
provides a specific implementation of `crud/new-identifier`