### PR TITLE
Improved collector: uniqueness of user/connector pairs and filtering of unusable pairs

### DIFF
--- a/jar-async/build.boot
+++ b/jar-async/build.boot
@@ -1,0 +1,50 @@
+(def +version+ "3.10-SNAPSHOT")
+
+(set-env!
+  :project 'com.sixsq.slipstream/SlipStreamAsync
+  :version +version+
+  :license {"Apache 2.0" "http://www.apache.org/licenses/LICENSE-2.0.txt"}
+  :edition "community"
+  
+  :dependencies '[[org.clojure/clojure "1.8.0"]
+                  [sixsq/build-utils "0.1.3" :scope "test"]])
+
+(require '[sixsq.build-fns :refer [merge-defaults
+                                   sixsq-nexus-url
+                                   lein-generate]])
+
+(set-env!
+  :repositories
+  #(reduce conj % [["sixsq" {:url (sixsq-nexus-url)}]])
+
+  :dependencies
+  #(vec (concat %
+                (merge-defaults
+                 ['sixsq/default-deps (get-env :version)]
+                 '[[org.clojure/clojure]
+                   [org.clojure/core.async]
+
+                   [com.sixsq.slipstream/SlipStreamPersistence]
+                   [com.sixsq.slipstream/SlipStreamConnector]
+
+                   [adzerk/boot-test]
+                   [adzerk/boot-reload]
+                   [tolitius/boot-check]
+                   [boot-codox]]))))
+
+(require
+  '[adzerk.boot-test :refer [test]]
+  '[adzerk.boot-reload :refer [reload]]
+  '[tolitius.boot-check :refer [with-yagni with-eastwood with-kibit with-bikeshed]]
+  '[codox.boot :refer [codox]])
+
+(set-env!
+  :source-paths #{"test"}
+  :resource-paths #{"src"})
+
+(task-options!
+  pom {:project (get-env :project)
+       :version (get-env :version)}
+  test {:junit-output-to ""}
+  )
+

--- a/jar-async/project.clj
+++ b/jar-async/project.clj
@@ -1,18 +1,18 @@
-(defproject com.sixsq.slipstream/async "2.9.0-SNAPSHOT"
-  :description    "Clojure Async services"
-  :url            "http://sixsq.com"
-  :license        {:name "Apache License, Version 2.0"
-                   :url "http://www.apache.org/licenses/LICENSE-2.0"}
+(defproject com.sixsq.slipstream/async "3.10-SNAPSHOT"
+  :description "Clojure Async services"
+  :url "http://sixsq.com"
+  :license {:name "Apache License, Version 2.0"
+            :url  "http://www.apache.org/licenses/LICENSE-2.0"}
 
-  :source-paths   ["src"]
-  :test-paths     ["test"]
+  :source-paths ["src"]
+  :test-paths ["test"]
   :resource-paths ["resources"]
 
-  :dependencies   [[org.clojure/clojure                  "1.8.0"]
-                   [org.clojure/core.async               "0.2.374"]
-                   [com.sixsq.slipstream/SlipStreamAsync "3.3-SNAPSHOT"]]
-
-  :plugins        [[lein-expectations                    "0.0.7"]
-                   [lein-autoexpect                      "1.4.2"]
-                   [com.jakemccrary/lein-test-refresh    "0.5.5"]])
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.async "0.2.385"]
+                 ;[com.sixsq.slipstream/auth "3.10-SNAPSHOT"]
+                 [com.sixsq.slipstream/SlipStreamPersistence "3.10-SNAPSHOT"]
+                 [com.sixsq.slipstream/SlipStreamConnector "3.10-SNAPSHOT"]
+                 ]
+  )
 

--- a/jar-async/src/slipstream/async/collector.clj
+++ b/jar-async/src/slipstream/async/collector.clj
@@ -27,13 +27,17 @@
 (def timeout-collect-reader-release (+ timeout-collect (seconds-in-msecs 2)))
 (def timeout-processing-loop        (seconds-in-msecs 60))
 
-(defn get-name
+(defn- get-name
   [user]
   (.getName user))
 
-(defn get-conn-inst-name
+(defn- get-conn-inst-name
   [connector]
   (.getConnectorInstanceName connector))
+
+(defn- tuple-uc
+  [u c]
+  [(get-name u) (get-conn-inst-name c)])
 
 (def busy (atom #{}))
 
@@ -45,16 +49,17 @@
  [current-busy v]
  (disj current-busy v))
 
-(defn- busy? [u c]
-  (@busy [(get-name u) (get-conn-inst-name c)]))
+(defn- busy?
+  [u c]
+  (@busy (tuple-uc u c)))
 
 (defn- busy!
   [u c]
-  (swap! busy mark-busy [(get-name u) (get-conn-inst-name c)]))
+  (swap! busy mark-busy (tuple-uc u c)))
 
 (defn- free!
   [u c]
-  (swap! busy mark-free [(get-name u) (get-conn-inst-name c)]))
+  (swap! busy mark-free (tuple-uc u c)))
 
 (defn full?
   []
@@ -94,7 +99,7 @@
 
 (defn- user-connector
  [user connector]
- (apply str "[" (get-name user) "/" (get-conn-inst-name connector) "] " (System/currentTimeMillis) " "))
+ (apply format "[%s/%s] %s " (conj (tuple-uc user connector) (System/currentTimeMillis))))
 
 (defn- build-msg
   [user connector elapsed & info]

--- a/jar-async/src/slipstream/async/collector.clj
+++ b/jar-async/src/slipstream/async/collector.clj
@@ -1,11 +1,10 @@
 (ns slipstream.async.collector
-  (:require 
+  (:require
     [slipstream.async.log             :as log]
     [slipstream.async.metric-updator  :as updator]
-    [clojure.core.async               :as async :refer [go timeout thread chan sliding-buffer <! >! <!! alts!]])
-  (:import 
+    [clojure.core.async               :refer [go timeout thread chan sliding-buffer <! >! <!! alts!]])
+  (:import
     [com.sixsq.slipstream.connector    Collector]
-    [com.sixsq.slipstream.connector    Connector]
     [com.sixsq.slipstream.connector    ConnectorFactory]
     [com.sixsq.slipstream.persistence  User])
   (:gen-class
@@ -20,7 +19,7 @@
   [msecs]
   (/ msecs 1000))
 
-(def collector-chan-size            512)
+(def collector-chan-size            1024)
 (def number-of-readers              32)
 (def timeout-all-users-loop         (seconds-in-msecs 240))
 (def timeout-online-loop            (seconds-in-msecs 10))
@@ -31,6 +30,10 @@
 (defn get-name
   [user]
   (.getName user))
+
+(defn get-conn-inst-name
+  [connector]
+  (.getConnectorInstanceName connector))
 
 (def busy (atom #{}))
 
@@ -43,21 +46,21 @@
  (disj current-busy v))
 
 (defn- busy? [u c]
-  (@busy [(get-name u) c]))
+  (@busy [(get-name u) (get-conn-inst-name c)]))
 
 (defn- busy!
   [u c]
-  (swap! busy mark-busy [(get-name u) c]))
+  (swap! busy mark-busy [(get-name u) (get-conn-inst-name c)]))
 
 (defn- free!
   [u c]
-  (swap! busy mark-free [(get-name u) c]))
+  (swap! busy mark-free [(get-name u) (get-conn-inst-name c)]))
 
-(defn full?   
+(defn full?
   []
   (>= (count @busy) collector-chan-size))
 
-(defn current-working-usage   
+(defn current-working-usage
   []
   (let [current-working (count @busy)
         ratio           (* 100.0 (/ current-working (float collector-chan-size)))]
@@ -91,7 +94,7 @@
 
 (defn- user-connector
  [user connector]
- (apply str "[" (get-name user) "/" (.getConnectorInstanceName connector) "] " (System/currentTimeMillis) " "))
+ (apply str "[" (get-name user) "/" (get-conn-inst-name connector) "] " (System/currentTimeMillis) " "))
 
 (defn- build-msg
   [user connector elapsed & info]
@@ -129,7 +132,7 @@
     (go
       (let [ [v _]    (alts! [ch (timeout timeout-collect-reader-release)])
              elapsed  (- (System/currentTimeMillis) start-ts) ]
-        (free! user connector)        
+        (free! user connector)
         (cond
           (nil? v)                            (log-timeout user connector elapsed)
           (= v Collector/NO_CREDENTIALS)      (log-no-credentials user connector elapsed)
@@ -149,7 +152,7 @@
     (go
       (while true
         (let [[[user connector] ch] (alts! [chan (timeout timeout-processing-loop)])]
-          (when (not-nil? user)            
+          (when (not-nil? user)
             (try
               (log/log-debug "Will execute collect request for " (user-connector user connector))
               (collect! user connector)
@@ -159,53 +162,77 @@
 (defonce ^:dynamic *all-collect-processor* (collect-readers all-collector-chan))
 
 (defn add-increasing-space
- [ucs space]
- (let [spaces (iterate #(+ space %) 0)]
+ [ucs step]
+ (let [spaces (iterate #(+ step %) 0)]
    (map conj ucs spaces)))
 
-(defn warn-channel-full   
+(defn warn-channel-full
   [context u c]
-  (log/log-error context 
+  (log/log-error context
     ": the processing channel capacity(" collector-chan-size") is currently full, will *not* insert request for "
       (user-connector u c)))
 
-(defn inform-avoiding   
+(defn inform-avoiding
   [context u c]
   (log/log-info context ": avoiding inserting on " (user-connector u c) " being already processed."))
 
-(defn inform-inserted 
+(defn inform-inserted
   [context u c t]
-  (log/log-debug context ": inserted collect request for " (user-connector u c) " after timeout " t))    
+  (log/log-debug context ": inserted collect request for " (user-connector u c) " after timeout " t))
 
-(defn inform-nothing-to-do 
+(defn inform-nothing-to-do
   [context]
   (log/log-debug context ": no users to collect."))
 
-(defn show-current-channel-usage   
+(defn show-current-channel-usage
   [context]
   (let [[current total ratio] (current-working-usage)]
-    (log/log-info context ": " current " / " total " => " ratio " %")))
+    (log/log-info "indirect channel usage before inserting collect requests for " context ": " current " / " total " => " ratio " %")))
+
+(defn log-initial-workspace
+  [nu nc]
+  (log/log-debug "Requested work on #" nu " users and #" nc " connectors. Initial workspace: " (* nu nc)))
+
+(defn log-final-workspace
+  [n]
+  (log/log-debug "After filtering out users w/o connector creds. Final workspace: " n))
+
+(defn log-spread
+  [s t]
+  (log/log-debug "Will spread " s " requests in " (msecs-in-seconds t) " s."))
+
+(defn insert-collection-request-cond-spaced
+  [chan u c t context]
+  (go
+    (<! (timeout t))
+    (if-not (busy? u c)
+      (do
+        (busy! u c)
+        (>! chan [u c])
+        (inform-inserted context u c t))
+      (inform-avoiding context u c))))
+
+(defn compose-uc-pairs
+  [users connectors]
+  (remove nil?
+          (for [u users c connectors]
+            (when (.isCredentialsSet c u) [u c]))))
 
 (defn insert-collection-requests
   [users connectors chan time-to-spread context]
   (show-current-channel-usage context)
   (if (every? (comp pos? count) [connectors users])
-    (let [ucs   (for [u users c connectors] [u c])
-          ucts  (add-increasing-space ucs (int (/ time-to-spread (count ucs))))]
+    (let [_ (log-initial-workspace (count users) (count connectors))
+          ucs (compose-uc-pairs users connectors)
+          _ (log-final-workspace (count ucs))
+          ucts (add-increasing-space ucs (int (/ time-to-spread (count ucs))))
+          _ (log-spread (count ucts) time-to-spread)]
       (doseq [[u c t] ucts]
-        (cond 
-          (full?)     (warn-channel-full context u c)
-          (busy? u c) (inform-avoiding context u c))
-          :else       (go
-                        (<! (timeout t))
-                        (if-not (busy? u c)
-                          (do
-                            (busy! u c)
-                            (>! chan [u c])
-                            (inform-inserted context u c t))
-
-                          (inform-avoiding context u c)))))
-    (inform-nothing-to-do context)))
+        (cond
+          (full?) (warn-channel-full context u c)
+          (busy? u c) (inform-avoiding context u c)
+          :else (insert-collection-request-cond-spaced chan u c t context)))
+      (inform-nothing-to-do context))))
 
 ; Start collector writers
 (defn collect-writers

--- a/jar-async/src/slipstream/async/collector.clj
+++ b/jar-async/src/slipstream/async/collector.clj
@@ -214,9 +214,7 @@
 
 (defn compose-uc-pairs
   [users connectors]
-  (remove nil?
-          (for [u users c connectors]
-            (when (.isCredentialsSet c u) [u c]))))
+  (for [u users c connectors :when (.isCredentialsSet c u)] [u c]))
 
 (defn insert-collection-requests
   [users connectors chan time-to-spread context]

--- a/jar-async/test/slipstream/async/collector_test.clj
+++ b/jar-async/test/slipstream/async/collector_test.clj
@@ -1,11 +1,35 @@
 (ns slipstream.async.collector-test
-  (:require    
-    [clojure.test                 :refer :all]
-    [slipstream.async.collector   :refer :all]))
+  (:require
+    [clojure.test :refer :all]
+    [slipstream.async.collector :refer :all])
+  (:import
+    [com.sixsq.slipstream.connector.local LocalConnector]
+    [com.sixsq.slipstream.connector.local LocalConnector]
+    [com.sixsq.slipstream.persistence User]
+    [com.sixsq.slipstream.persistence UserParameter]))
 
 (deftest test-add-increasing-space
   (is (= [["joe" "exo" 0] ["joe" "aws" 10] ["mike" "exo" 20]]
-         (add-increasing-space [["joe" "exo"] ["joe" "aws"] ["mike" "exo"]] 10))))
-  
+         (add-increasing-space [["joe" "exo"] ["joe" "aws"] ["mike" "exo"]] 10)))
+  (is (= [["joe" "exo" 0] ["joe" "aws" 1] ["mike" "exo" 2]]
+         (add-increasing-space [["joe" "exo"] ["joe" "aws"] ["mike" "exo"]] 1)))
+  )
 
+(def connector (LocalConnector. "c1"))
+(def user-no-connector (User. "foo"))
+(def user-with-connector
+  (doto (User. "foo")
+    (.setParameter (UserParameter. "c1.username" "user" "Cloud username."))
+    (.setParameter (UserParameter. "c1.password" "pass" "Cloud password."))))
+
+(deftest test-compose-uc-pairs
+  (is (= 0 (count (compose-uc-pairs [] []))))
+  (is (= 0 (count (compose-uc-pairs [user-with-connector] []))))
+  (is (= 0 (count (compose-uc-pairs [] [connector]))))
+  (is (= 0 (count (compose-uc-pairs [user-no-connector] [connector]))))
+  (is (= 1 (count (compose-uc-pairs [user-with-connector] [connector]))))
+  (is (= 1 (count (compose-uc-pairs [user-no-connector user-with-connector] [connector]))))
+  (is (= 2 (count (compose-uc-pairs [user-with-connector user-with-connector] [connector]))))
+  (is (= 4 (count (compose-uc-pairs [user-with-connector user-with-connector] [connector connector]))))
+  (is (= 2 (count (compose-uc-pairs [user-with-connector user-with-connector] [connector (LocalConnector. "c2")])))))
 


### PR DESCRIPTION
Improvements/changes

- uniqueness of user/connector pairs in the local bookkeeping atom;
- filtering out of unusable user/connector pairs; added unit test;
- improved logging;
- added boot's build.boot  (Leinegen now is failing in REPL).

Connected to #795 