### PR TITLE
block main thread to avoid premature termination of server

### DIFF
--- a/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/app/main.clj
+++ b/ssclj/jar/src/main/clojure/com/sixsq/slipstream/ssclj/app/main.clj
@@ -35,4 +35,10 @@
   (-> (parse-port port)
       (or default-port)
       (server/start)
-      (register-shutdown-hook)))
+      (register-shutdown-hook))
+
+  ;; The server (started as a daemon thread) will exit immediately
+  ;; if the main thread is allowed to terminate.  To avoid this,
+  ;; indefinitely block this thread.  Stopping the service can only
+  ;; be done externally through a SIGTERM signal.
+  @(promise))


### PR DESCRIPTION
Connected to #807.

Must block the main thread to avoid having server exit immediately. 