### PR TITLE
don't skip publication of auth-dep POM artifact

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -67,20 +67,6 @@
     <plugins>
 
       <plugin>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <executions>


### PR DESCRIPTION
Otherwise, build of artefacts depending on `SlipStreamClient` fail.

Connected to #815 