### PR TITLE
Fixes

### DIFF
--- a/jar-async/src/slipstream/async/collector.clj
+++ b/jar-async/src/slipstream/async/collector.clj
@@ -58,18 +58,19 @@
   (swap! busy mark-busy (tuple-uc u c)))
 
 (defn- free!
-  [u c]
-  (swap! busy mark-free (tuple-uc u c)))
+  [tuple-uc]
+  (swap! busy mark-free tuple-uc))
 
 (defn full?
   []
-  (>= (count @busy) collector-chan-size))
+  (>= (count @busy) (* 2.0 collector-chan-size)))
 
 (defn current-working-usage
   []
   (let [current-working (count @busy)
-        ratio           (* 100.0 (/ current-working (float collector-chan-size)))]
-    [current-working collector-chan-size ratio]))
+        total           (* 2 collector-chan-size) ; * 2 because there are 2 channels (offline and online users)
+        ratio           (* 100.0 (/ current-working (float total)))]
+    [current-working total ratio]))
 
 (defn get-value
   [entry]
@@ -98,28 +99,28 @@
 (def all-collector-chan (chan (sliding-buffer collector-chan-size)))
 
 (defn- user-connector
- [user connector]
- (apply format "[%s/%s] %s " (conj (tuple-uc user connector) (System/currentTimeMillis))))
+ [tuple-uc]
+ (apply format "[%s/%s]" tuple-uc))
 
 (defn- build-msg
-  [user connector elapsed & info]
-  (apply str (user-connector user connector) " (" elapsed " ms) : " info))
+  [worker-id tuple-uc elapsed & info]
+  (apply str worker-id " " (user-connector tuple-uc) " (" elapsed " ms) : " info))
 
 (defn log-timeout
-  [user connector elapsed]
-  (log/log-error (build-msg user connector elapsed "Timed out when waiting for collecting vms")))
+  [worker-id tuple-uc elapsed]
+  (log/log-error (build-msg worker-id tuple-uc elapsed "Timed out when waiting for collecting vms")))
 
 (defn log-failure
-  [user connector elapsed]
-  (log/log-error (build-msg user connector elapsed "Failed collecting VMs")))
+  [worker-id tuple-uc elapsed]
+  (log/log-error (build-msg worker-id tuple-uc elapsed "Failed collecting VMs")))
 
 (defn log-collected
-  [user connector elapsed v]
-  (log/log-info (build-msg user connector elapsed "Number of VMs collected = " v)))
+  [worker-id tuple-uc elapsed v]
+  (log/log-info (build-msg worker-id tuple-uc elapsed "Number of VMs collected = " v)))
 
 (defn log-no-credentials
-  [user connector elapsed]
-  (log/log-debug (build-msg user connector elapsed "The user has no credentials for this Cloud")))
+  [worker-id tuple-uc elapsed]
+  (log/log-debug (build-msg worker-id tuple-uc elapsed "The user has no credentials for this Cloud")))
 
 (defn update-metric!
   [user connector]
@@ -132,39 +133,67 @@
     (go (>! ch (updator/update-metric user connector)))))
 
 (defn collect!
-  [user connector w-id]
-  (let [ch (chan 1) start-ts (System/currentTimeMillis)]
+  [user connector worker-id]
+  (let [ch        (chan 1)
+        start-ts  (System/currentTimeMillis)]
     (go
-      (let [ [v _]    (alts! [ch (timeout timeout-collect-reader-release)])
-             elapsed  (- (System/currentTimeMillis) start-ts) ]
-        (free! user connector)
+      (let [[v _]     (alts! [ch (timeout timeout-collect-reader-release)])
+            elapsed   (- (System/currentTimeMillis) start-ts)
+            tuple-uc  (tuple-uc user connector)]
+        (free! tuple-uc)
         (cond
-          (nil? v)                            (log-timeout user connector elapsed)
-          (= v Collector/NO_CREDENTIALS)      (log-no-credentials user connector elapsed)
-          (= v Collector/EXCEPTION_OCCURRED)  (log-failure user connector elapsed)
+          (nil? v)                            (log-timeout worker-id tuple-uc elapsed)
+          (= v Collector/NO_CREDENTIALS)      (log-no-credentials worker-id tuple-uc elapsed)
+          (= v Collector/EXCEPTION_OCCURRED)  (log-failure worker-id tuple-uc elapsed)
           :else (do
-                  (log-collected user connector elapsed v)
+                  (log-collected worker-id tuple-uc elapsed v)
                   (when (updator/metering-enabled?) (update-metric! user connector))))))
-    (go (>! ch (Collector/collect user connector (msecs-in-seconds timeout-collect) w-id)))))
+    (go
+      (log/log-debug "will collect for worker-id " (class worker-id) worker-id)
+      (>! ch (Collector/collect user connector (msecs-in-seconds timeout-collect) worker-id)))))
 
 (def not-nil? (complement nil?))
 
+(defn worker-id
+  [channel-name i]
+  (str "Worker-" channel-name "/" i))
+
+(defmacro forever
+  "A macro that runs body in a while true loop, guarded by a try catch block.
+  The body typically performs an action and waits for some time.
+  Context parameter is used to report information when exception is caught.
+
+  This is a macro (instead of regular function) because of a core.async limitation. Otherwise, we get:
+  Uncaught Error: alts! used not in (go …) block
+  "
+  [context & body]
+  `(try
+    (while true
+      (log/log-info "Executing " ~context)
+      ~@body)
+    (catch Exception e#
+      (log/log-warn ~context " caught exception : " (.getMessage e#)))))
+
+(defn- go-collect
+  "Launches in a go thread an infinite loop that collects VM for user/cloud"
+  [chan worker-id]
+  (go
+    (log/log-info "Go thread started for " worker-id)
+    (forever (str "Collection for " worker-id)
+             (let [[[user connector] _] (alts! [chan (timeout timeout-processing-loop)])]
+               (when (not-nil? user)
+                 (log/log-info worker-id " will execute collect request for " (user-connector (tuple-uc user connector)))
+                 (collect! user connector worker-id))))))
+
 ; Start collector readers
 (defn collect-readers
-  [chan]
-  (log/log-debug "Starting " number-of-readers " collector readers...")
+  [chan channel-name]
+  (log/log-info channel-name ", will start " number-of-readers " collector readers.")
   (doseq [i (range number-of-readers)]
-    (go
-      (while true
-        (let [[[user connector] _] (alts! [chan (timeout timeout-processing-loop)])]
-          (when (not-nil? user)
-            (try
-              (log/log-debug "Will execute collect request for " (user-connector user connector))
-              (collect! user connector i)
-              (catch Exception e (log/log-warn "caught exception executing collect request: " (.getMessage e))))))))))
+    (go-collect chan (worker-id channel-name i))))
 
-(defonce ^:dynamic *online-collect-processor* (collect-readers online-collector-chan))
-(defonce ^:dynamic *all-collect-processor* (collect-readers all-collector-chan))
+(defonce ^:dynamic *online-collect-processor* (collect-readers online-collector-chan "online"))
+(defonce ^:dynamic *all-collect-processor* (collect-readers all-collector-chan "offline"))
 
 (defn add-increasing-space
  [ucs step]
@@ -172,22 +201,22 @@
    (map conj ucs spaces)))
 
 (defn warn-channel-full
-  [context u c]
+  [context tuple-uc]
   (log/log-error context
     ": the processing channel capacity(" collector-chan-size") is currently full, will *not* insert request for "
-      (user-connector u c)))
+      (user-connector tuple-uc)))
 
 (defn inform-avoiding
-  [context u c]
-  (log/log-info context ": avoiding inserting on " (user-connector u c) " being already processed."))
+  [context tuple-uc]
+  (log/log-info context ": avoiding inserting on " (user-connector tuple-uc) " being already processed."))
 
 (defn inform-inserted
-  [context u c t]
-  (log/log-debug context ": inserted collect request for " (user-connector u c) " after timeout " t))
+  [context tuple-uc t]
+  (log/log-debug context ": inserted collect request for " (user-connector tuple-uc) " after timeout " t))
 
 (defn inform-nothing-to-do
   [context]
-  (log/log-debug context ": no users to collect."))
+  (log/log-info context ": no users to collect."))
 
 (defn show-current-channel-usage
   [context users]
@@ -216,8 +245,8 @@
       (do
         (busy! u c)
         (>! chan [u c])
-        (inform-inserted context u c t))
-      (inform-avoiding context u c))))
+        (inform-inserted context (tuple-uc u c) t))
+      (inform-avoiding context (tuple-uc u c)))))
 
 (defn compose-uc-pairs
   [users connectors]
@@ -226,28 +255,27 @@
 (defn insert-collection-requests
   [users connectors chan time-to-spread context]
   (show-current-channel-usage context users)
-  (if (every? (comp pos? count) [connectors users])
-    (let [ucs   (for [u users c connectors] [u c])
-          ucts  (add-increasing-space ucs (int (/ time-to-spread (count ucs))))
-          _     (log-spread (count ucts) time-to-spread)]
-      (doseq [[u c t] ucts]
-        (cond
-          (full?)     (warn-channel-full context u c)
-          (busy? u c) (inform-avoiding context u c)
-          :else       (insert-collection-request-cond-spaced chan u c t context)))
+  (let [ucs (compose-uc-pairs users connectors)]
+    (if-not (empty? ucs)
+      (let [ucts (add-increasing-space ucs (int (/ time-to-spread (count ucs))))]
+        (doseq [[u c t] ucts]
+          (cond
+            (full?)     (warn-channel-full context (tuple-uc u c))
+            (busy? u c) (inform-avoiding context (tuple-uc u c))
+            :else       (insert-collection-request-cond-spaced chan u c t context))))
       (inform-nothing-to-do context))))
 
 ; Start collector writers
 (defn collect-writers
   []
   (go
-    (while true
-      (insert-collection-requests (online-users) (connectors) online-collector-chan timeout-online-loop "online users")
-      (<! (timeout timeout-online-loop))))
+    (forever "Writing online users collection"
+             (insert-collection-requests (online-users) (connectors) online-collector-chan timeout-online-loop "online users")
+             (<! (timeout timeout-online-loop))))
   (go
-    (while true
-      (insert-collection-requests (users) (connectors) all-collector-chan timeout-all-users-loop "all users")
-      (<! (timeout timeout-all-users-loop)))))
+    (forever "Writing offline users collection"
+             (insert-collection-requests (users) (connectors) all-collector-chan timeout-all-users-loop "offline users")
+             (<! (timeout timeout-all-users-loop)))))
 
 (defn -start
   []

--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/Collector.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/Collector.java
@@ -43,10 +43,10 @@ public class Collector {
 	public static final int NO_CREDENTIALS = -1;
 
 	public static int collect(User user, Connector connector, int timeout) {
-		return collect(user, connector, timeout, 0);
+		return collect(user, connector, timeout, "test-worker");
 	}
 
-	public static int collect(User user, Connector connector, int timeout, int workerId) {
+	public static int collect(User user, Connector connector, int timeout, String workerId) {
 		int res = EXCEPTION_OCCURRED;
 		if (connector.isCredentialsSet(user)) {
 			String uuid = UUID.randomUUID().toString();

--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/UsageEvent.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/UsageEvent.java
@@ -103,10 +103,10 @@ public class UsageEvent {
 
             Context context = new Context();
             Series<Parameter> parameters = context.getParameters();
-            parameters.add("socketTimeout", "1000");
-            parameters.add("idleTimeout", "1000");
-            parameters.add("idleCheckInterval", "1000");
-            parameters.add("socketConnectTimeoutMs", "1000");
+            parameters.add("socketTimeout", "60000");
+            parameters.add("idleTimeout", "60000");
+            parameters.add("idleCheckInterval", "0");
+            parameters.add("socketConnectTimeoutMs", "15000");
 
             resource = new ClientResource(context, SSCLJ_SERVER + "/" + USAGE_EVENT_RESOURCE_NAME);
             resource.setRetryOnError(false);


### PR DESCRIPTION
* avoid division by zero in online loop (when users do not have
configured connectors)
* factor out code in macro forever for infinite loop guarded by
try/catch
* relax parameters when posting on usage-event resource

Connected to #849