### PR TITLE
don't build uberjar for ssclj tools - use jars provided by ssclj

### DIFF
--- a/ssclj/rpm/src/main/tools/config/ssclj-tools-cli
+++ b/ssclj/rpm/src/main/tools/config/ssclj-tools-cli
@@ -1,3 +1,3 @@
 SSCLJ_LOC=${installation.dir}
-export CLASSPATH=$SSCLJ_LOC/tools/resources/:$SSCLJ_LOC/lib/ext/*:$SSCLJ_LOC/*:$SSCLJ_LOC/tools/*
+export CLASSPATH=$SSCLJ_LOC/tools/resources/:$SSCLJ_LOC/lib/*:$SSCLJ_LOC/lib/ext/*:$SSCLJ_LOC/*:$SSCLJ_LOC/tools/*
 

--- a/ssclj/tools/build.boot
+++ b/ssclj/tools/build.boot
@@ -74,7 +74,6 @@
            (aot :namespace #{'com.sixsq.slipstream.tools.cli.ssconfig
                              'com.sixsq.slipstream.tools.cli.ssconfigdump
                              'com.sixsq.slipstream.tools.cli.ssconfigmigrate})
-           (uber)
            (jar)))
 
 (deftask mvn-test


### PR DESCRIPTION
Connected to #862 