### PR TITLE
fix username for pricing server

### DIFF
--- a/rpm-prs/src/main/default/ss-pricing
+++ b/rpm-prs/src/main/default/ss-pricing
@@ -1,6 +1,6 @@
 SS_PORT=8203
 SS_CIMI_CLOUD_ENTRY_POINT="http://localhost:8201/api/cloud-entry-point"
-SS_CIMI_USERNAME="user"
+SS_CIMI_USERNAME="super"
 SS_CIMI_PASSWORD="secret"
 SS_URL_LOGIN="http://localhost:8201/auth/login"
 SS_URL_LOGOUT="http://localhost:8201/auth/logout"


### PR DESCRIPTION
Connected to #935.  Username must be 'super' for default installation script to correctly insert credentials.