### PR TITLE
add SS logging config to the jetty start.ini directly

### DIFF
--- a/rpm/src/main/jetty-config/etc/jetty.conf
+++ b/rpm/src/main/jetty-config/etc/jetty.conf
@@ -11,6 +11,5 @@
 --exec
 -Dslipstream.config.dir=/etc/slipstream
 
-jetty-logging-ss.xml
 jetty-started.xml
 

--- a/rpm/src/main/jetty-config/modules/logging-ss.mod
+++ b/rpm/src/main/jetty-config/modules/logging-ss.mod
@@ -1,0 +1,14 @@
+#
+# SlipStream logging
+#
+
+[xml]
+etc/jetty-logging-ss.xml
+
+[files]
+logs/
+
+[lib]
+resources/
+
+[ini-template]

--- a/rpm/src/main/jetty-config/start.ini
+++ b/rpm/src/main/jetty-config/start.ini
@@ -145,3 +145,34 @@ jetty.http.port=8182
 #--module=jstl
 
 
+# ---------------------------------------
+# Module: logging-ss
+--module=logging-ss
+
+
+# ---------------------------------------
+# Module: logging
+--module=logging
+
+## Logging Configuration
+## Configure jetty logging for default internal behavior STDERR output
+# -Dorg.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
+
+## Configure jetty logging for slf4j
+# -Dorg.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.Slf4jLog
+
+## Configure jetty logging for java.util.logging
+# -Dorg.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.JavaUtilLog
+
+## Logging directory (relative to $jetty.base)
+# jetty.logging.dir=logs
+
+## Whether to append to existing file
+# jetty.logging.append=false
+
+## How many days to retain old log files
+# jetty.logging.retainDays=90
+
+## Timezone of the log timestamps
+# jetty.logging.timezone=GMT
+


### PR DESCRIPTION
This fixes an issue when adding other modules to the startup (like `jmx-remote`) breaks the logging format.  This is because `jetty-*.xml` files configured in `etc/jetty.conf` come after the ones configured as loadable modules in `start.ini`.

Connected to #942