### PR TITLE
Allow to update a User in XML without having to set the "password" and "roles" attributes

### DIFF
--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/User.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/User.java
@@ -277,7 +277,19 @@ public class User extends Parameterized<User, UserParameter> {
 	}
 
 	public void hashAndSetPassword(String password) throws NoSuchAlgorithmException, UnsupportedEncodingException {
-		setHashedPassword(Passwords.hash(password));
+		String hashedPassword = "";
+		if (password != null && !password.isEmpty()) {
+			hashedPassword = Passwords.hash(password);
+		}
+		setHashedPassword(hashedPassword);
+	}
+
+	public boolean setPasswordFromUserIfNull(User user) throws ValidationException {
+		if (password == null && user != null) {
+			setHashedPassword(user.password);
+			return true;
+		}
+		return false;
 	}
 
 	@Attribute(name = "password", required = false)
@@ -554,6 +566,14 @@ public class User extends Parameterized<User, UserParameter> {
 
 	public void setAuthnToken(String authnToken) {
 		this.authnToken = authnToken;
+	}
+
+	public boolean setRolesFromUserIfNull(User user) throws ValidationException {
+		if (roles == null && user != null) {
+			setRoles(user.roles);
+			return true;
+		}
+		return false;
 	}
 
 	public String getRoles() {

--- a/jar-service/src/main/java/com/sixsq/slipstream/initialstartup/Users.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/initialstartup/Users.java
@@ -171,9 +171,7 @@ public class Users {
         }
         try {
             user.setPassword(password);
-        } catch (NoSuchAlgorithmException e) {
-            Logger.warning("Failed setting password for user: " + user.getName() + " with error: " + e.getMessage());
-        } catch (UnsupportedEncodingException e) {
+        } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
             Logger.warning("Failed setting password for user: " + user.getName() + " with error: " + e.getMessage());
         }
 

--- a/jar-service/src/main/java/com/sixsq/slipstream/user/UserResource.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/user/UserResource.java
@@ -308,7 +308,7 @@ public class UserResource extends ParameterizedResource<User> {
 				throwClientForbiddenError("Only super users are authorized to create a privileged user!");
 			}
 			if (user.getRoles() != null) {
-				throwClientForbiddenError("Only super users are authorized to set roles!");
+				throwClientForbiddenError("Only super users are authorized to update roles!");
 			}
 		}
 
@@ -360,6 +360,10 @@ public class UserResource extends ParameterizedResource<User> {
 		} catch (ValidationException ex) {
 			throw new ResourceException(Status.CLIENT_ERROR_CONFLICT, ex.getMessage());
 		}
+
+		User existingUser = getParameterized();
+		user.setRolesFromUserIfNull(existingUser);
+		user.setPasswordFromUserIfNull(existingUser);
 
 		try {
 			User.validateMinimumInfo(user);

--- a/jar-service/src/test/java/com/sixsq/slipstream/initialstartup/UsersTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/initialstartup/UsersTest.java
@@ -22,6 +22,7 @@ package com.sixsq.slipstream.initialstartup;
 
 import static org.junit.Assert.assertEquals;
 
+import com.sixsq.slipstream.exceptions.InvalidElementException;
 import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
@@ -62,5 +63,23 @@ public class UsersTest {
 		assertEquals(
 				"4AAEC1C5E8C60370F95D0935EFCAA3245736439203E91742D4686AA50C3FBA96A567909567BE623F033500591132DC5BDB8DDB27E0587DB97A986EC92245FC80",
 				userSuper.getHashedPassword());
+	}
+
+	@Test(expected = InvalidElementException.class)
+	public void passwordCannotBeEmpty() throws ValidationException, NotFoundException, ConfigurationException,
+			NoSuchAlgorithmException, UnsupportedEncodingException, InvalidElementException {
+		// The create function will not initialize the accounts if they
+		// already exist.  Ensure that all of the standard accounts have
+		// been removed from the database.
+		if (User.loadByName("super") != null) {
+			User.removeNamedUser("super");
+		}
+
+		Users.create();
+
+		User user = User.loadByName("super");
+		user.setPassword(null);
+		user.validate();
+		User.validateMinimumInfo(user);
 	}
 }


### PR DESCRIPTION
Other bugs fixed:
- Fixed a bug which was preventing the detection of empty passwords.
- Fixed a bug which was allowing an unprivileged user to reset it's roles.

Connected to #904