### PR TITLE
Fix performance issues with Module

### DIFF
--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/DeploymentModule.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/DeploymentModule.java
@@ -22,6 +22,8 @@ package com.sixsq.slipstream.persistence;
 
 import com.sixsq.slipstream.exceptions.ValidationException;
 import org.hibernate.annotations.CollectionType;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.simpleframework.xml.ElementMap;
 
 import javax.persistence.CascadeType;
@@ -42,6 +44,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class DeploymentModule extends TargetContainerModule {
 
 	@ElementMap(required = false)
+	@Fetch(FetchMode.SELECT)
 	@OneToMany(mappedBy = "module", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
 	@CollectionType(type = "com.sixsq.slipstream.persistence.ConcurrentHashMapType")
 	private Map<String, Node> nodes = new ConcurrentHashMap<String, Node>();

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/ImageModule.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/ImageModule.java
@@ -31,6 +31,8 @@ import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
 import javax.persistence.Transient;
 
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.simpleframework.xml.*;
 
 import com.sixsq.slipstream.exceptions.ConfigurationException;
@@ -79,6 +81,7 @@ public class ImageModule extends TargetContainerModule {
 	}
 
 	@ElementList(required = false)
+	@Fetch(FetchMode.SELECT)
 	@OneToMany(mappedBy = "module", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
 	private Set<Package> packages = new HashSet<Package>();
 
@@ -106,6 +109,7 @@ public class ImageModule extends TargetContainerModule {
 
 	private String platform = "other";
 
+	@Fetch(FetchMode.SELECT)
 	@OneToMany(mappedBy = "container", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
 	@ElementList(required = false, data = true)
 	private Set<CloudImageIdentifier> cloudImageIdentifiers = new HashSet<CloudImageIdentifier>();

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Module.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Module.java
@@ -138,6 +138,16 @@ public abstract class Module extends Parameterized<Module, ModuleParameter> impl
 	}
 
 	@SuppressWarnings("unchecked")
+	public static boolean isEmpty() {
+		EntityManager em = PersistenceUtil.createEntityManager();
+		Query q = em.createNamedQuery("moduleAll");
+		q.setMaxResults(1);
+		List<Module> list = q.getResultList();
+		em.close();
+		return list.size() == 0;
+	}
+
+	@SuppressWarnings("unchecked")
 	public static List<ModuleView> viewList(String resourceUri) {
 		EntityManager em = PersistenceUtil.createEntityManager();
 		Query q = em.createNamedQuery("moduleViewLatestChildren");

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/TargetContainerModule.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/TargetContainerModule.java
@@ -21,6 +21,8 @@ package com.sixsq.slipstream.persistence;
  */
 
 import com.sixsq.slipstream.exceptions.ValidationException;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.simpleframework.xml.ElementList;
 
 import javax.persistence.*;
@@ -32,6 +34,7 @@ import java.util.Set;
 public abstract class TargetContainerModule extends Module {
 
     @ElementList(required = false)
+    @Fetch(FetchMode.SELECT)
     @OneToMany(mappedBy = "module", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     protected Set<Target> targets = new HashSet<>();
 

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/User.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/User.java
@@ -485,6 +485,16 @@ public class User extends Parameterized<User, UserParameter> {
 	}
 
 	@SuppressWarnings("unchecked")
+	public static boolean isSuperAlone() {
+		EntityManager em = PersistenceUtil.createEntityManager();
+		Query q = em.createNamedQuery("allUsers");
+		q.setMaxResults(1);
+		List<User> list = q.getResultList();
+		em.close();
+		return list.size() == 1 && list.get(0).getName().equals("super");
+	}
+
+	@SuppressWarnings("unchecked")
 	public static List<User> listActive() {
 		EntityManager em = PersistenceUtil.createEntityManager();
 		Query q = em.createNamedQuery("activeUsers");

--- a/jar-service/src/main/java/com/sixsq/slipstream/initialstartup/Modules.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/initialstartup/Modules.java
@@ -58,13 +58,7 @@ public class Modules {
 	}
 
 	private static boolean shouldLoad() {
-		List<Module> modules = Module.listAll();
-
-		if (modules.size() > 0) {
-			return false; // there are already modules, we don't load
-		}
-
-		return true;
+		return Module.isEmpty();
 	}
 
 	private static void loadSingleModule(File f) {

--- a/jar-service/src/main/java/com/sixsq/slipstream/initialstartup/Users.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/initialstartup/Users.java
@@ -120,17 +120,7 @@ public class Users {
 	}
 
 	private static boolean shouldLoad() {
-		List<User> users = User.list();
-
-		if (users.size() != 1) {
-			return false; // by default we should only have one user
-		}
-
-		if(!users.get(0).getName().equals(SUPER_USERNAME)) {
-			return false; // and it should be super
-		}
-
-		return true;
+		return User.isSuperAlone();
 	}
 
 	private static void loadSingleUser(File f) {


### PR DESCRIPTION
Connected to #975 

- Use `FetchMode.SELECT` for `OneToMany` relations related to` Module` to prevent combinatory explosion with joins (cartesian product).
- Prevent SlipStream to load all `Modules` and all `Users` at startup to improve startup time.