### PR TITLE
allow url encoded session

### DIFF
--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/session.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/session.clj
@@ -277,7 +277,7 @@
     (let [id (str resource-url "/" uuid)]
       (-> (crud/retrieve-by-id id {:user-name  "INTERNAL"
                                    :user-roles [id]})       ;; Essentially turn off authz by spoofing owner of resource.
-          (validate-callback request)))                     ;; FIXME: Ensure that return value is correct.
+          (validate-callback request)))
     (catch ExceptionInfo ei
       (ex-data ei))))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_github_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_github_lifecycle_test.clj
@@ -47,6 +47,10 @@
         session-anon (-> (session (ring-app))
                          (content-type "application/json")
                          (header authn-info-header "unknown ANON"))
+        session-anon-form (-> (session (ring-app))
+                              (content-type session/form-urlencoded)
+                              (header "content-type" session/form-urlencoded)
+                              (header authn-info-header "unknown ANON"))
         redirect-uri "https://example.com/webui"]
 
     ;; get session template so that session resources can be tested
@@ -103,13 +107,27 @@
               id2 (get-in resp [:response :body :resource-id])
               uri2 (-> resp
                        (ltu/location))
-              abs-uri2 (str p/service-context id2)]
+              abs-uri2 (str p/service-context id2)
+
+              resp (-> session-anon-form
+                       (request base-uri
+                                :request-method :post
+                                :body (codec/form-encode {:href        href
+                                                          :redirectURI redirect-uri}))
+                       (ltu/body->edn)
+                       (ltu/is-status 303))
+              id3 (get-in resp [:response :body :resource-id])
+              uri3 (-> resp
+                       (ltu/location))
+              abs-uri3 (str p/service-context id3)]
 
           ;; redirect URLs in location header should contain the client ID and resource id
           (is (re-matches #".*FAKE_CLIENT_ID.*" (or uri "")))
           (is (re-matches (re-pattern (str ".*" (codec/url-encode id) ".*")) (or uri "")))
           (is (re-matches #".*FAKE_CLIENT_ID.*" (or uri2 "")))
           (is (re-matches (re-pattern (str ".*" (codec/url-encode id2) ".*")) (or uri2 "")))
+          (is (re-matches #".*FAKE_CLIENT_ID.*" (or uri3 "")))
+          (is (re-matches (re-pattern (str ".*" (codec/url-encode id3) ".*")) (or uri3 "")))
 
           ;; user should not be able to see session without session role
           (-> session-user
@@ -118,6 +136,10 @@
               (ltu/is-status 403))
           (-> session-user
               (request abs-uri2)
+              (ltu/body->edn)
+              (ltu/is-status 403))
+          (-> session-user
+              (request abs-uri3)
               (ltu/body->edn)
               (ltu/is-status 403))
 
@@ -161,6 +183,15 @@
               (ltu/is-operation-present "delete")
               (ltu/is-operation-present (:validate c/action-uri))
               (ltu/is-operation-absent "edit"))
+          (-> session-user
+              (header authn-info-header (str "user USER ANON " id3))
+              (request abs-uri3)
+              (ltu/body->edn)
+              (ltu/is-status 200)
+              (ltu/is-id id3)
+              (ltu/is-operation-present "delete")
+              (ltu/is-operation-present (:validate c/action-uri))
+              (ltu/is-operation-absent "edit"))
 
           ;; user query with session role should succeed but and have one entry
           (-> session-user
@@ -175,12 +206,19 @@
               (ltu/body->edn)
               (ltu/is-status 200)
               (ltu/is-count 1))
+          (-> session-user
+              (header authn-info-header (str "user USER ANON " id3))
+              (request base-uri)
+              (ltu/body->edn)
+              (ltu/is-status 200)
+              (ltu/is-count 1))
 
           ;;
           ;; test validation callback
           ;;
           (let [validate-url (str abs-uri "/validate")
-                validate-url2 (str abs-uri2 "/validate")]
+                validate-url2 (str abs-uri2 "/validate")
+                validate-url3 (str abs-uri3 "/validate")]
 
             ;; try hitting the callback with an invalid server configuration
             (with-redefs [environ.core/env {}]
@@ -197,6 +235,13 @@
                            :request-method :get)
                   (ltu/body->edn)
                   (ltu/message-matches #".*missing client ID.*")
+                  (ltu/is-status 500))
+
+              (-> session-anon
+                  (request validate-url3
+                           :request-method :get)
+                  (ltu/body->edn)
+                  (ltu/message-matches #".*missing client ID.*")
                   (ltu/is-status 500)))
 
             ;; try hitting the callback without the OAuth code parameter
@@ -209,6 +254,13 @@
 
             (-> session-anon
                 (request validate-url2
+                         :request-method :get)
+                (ltu/body->edn)
+                (ltu/message-matches #".*not contain required code.*")
+                (ltu/is-status 400))
+
+            (-> session-anon
+                (request validate-url3
                          :request-method :get)
                 (ltu/body->edn)
                 (ltu/message-matches #".*not contain required code.*")
@@ -269,7 +321,20 @@
                     claims (if token (sign/unsign-claims token) {})]
                 (is (= location redirect-uri))
                 (is (= "MATCHED_USER" (:username claims)))
-                (is (re-matches (re-pattern (str ".*" id2 ".*")) (or (:roles claims) ""))))))
+                (is (re-matches (re-pattern (str ".*" id2 ".*")) (or (:roles claims) ""))))
+
+              (let [ring-info (-> session-anon
+                                  (request (str validate-url3 "?code=GOOD")
+                                           :request-method :get)
+                                  (ltu/body->edn)
+                                  (ltu/is-status 303)
+                                  (ltu/is-set-cookie))
+                    location (ltu/location ring-info)
+                    token (get-in ring-info [:response :cookies "com.sixsq.slipstream.cookie" :value :token])
+                    claims (if token (sign/unsign-claims token) {})]
+                (is (= location redirect-uri))
+                (is (= "MATCHED_USER" (:username claims)))
+                (is (re-matches (re-pattern (str ".*" id3 ".*")) (or (:roles claims) ""))))))
 
           ;; check that the session has been updated
           (let [ring-info (-> session-user
@@ -298,6 +363,19 @@
             (is (= "MATCHED_USER" (:username session)))
             (is (not= (:created session) (:updated session))))
 
+          (let [ring-info (-> session-user
+                              (header authn-info-header (str "user USER ANON " id3))
+                              (request abs-uri3)
+                              (ltu/body->edn)
+                              (ltu/is-status 200)
+                              (ltu/is-id id3)
+                              (ltu/is-operation-present "delete")
+                              (ltu/is-operation-absent (:validate c/action-uri))
+                              (ltu/is-operation-absent "edit"))
+                session (get-in ring-info [:response :body])]
+            (is (= "MATCHED_USER" (:username session)))
+            (is (not= (:created session) (:updated session))))
+
           ;; user with session role can delete resource
           (-> session-user
               (header authn-info-header (str "user USER ANON " id))
@@ -309,6 +387,13 @@
           (-> session-user
               (header authn-info-header (str "user USER ANON " id2))
               (request abs-uri2
+                       :request-method :delete)
+              (ltu/is-unset-cookie)
+              (ltu/body->edn)
+              (ltu/is-status 200))
+          (-> session-user
+              (header authn-info-header (str "user USER ANON " id3))
+              (request abs-uri3
                        :request-method :delete)
               (ltu/is-unset-cookie)
               (ltu/body->edn)

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_oidc_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_oidc_lifecycle_test.clj
@@ -47,6 +47,10 @@
         session-anon (-> (session (ring-app))
                          (content-type "application/json")
                          (header authn-info-header "unknown ANON"))
+        session-anon-form (-> (session (ring-app))
+                              (content-type session/form-urlencoded)
+                              (header "content-type" session/form-urlencoded)
+                              (header authn-info-header "unknown ANON"))
         redirect-uri "https://example.com/webui"]
 
     ;; get session template so that session resources can be tested
@@ -110,13 +114,27 @@
                 id2 (get-in resp [:response :body :resource-id])
                 uri2 (-> resp
                          (ltu/location))
-                abs-uri2 (str p/service-context id2)]
+                abs-uri2 (str p/service-context id2)
+
+                resp (-> session-anon-form
+                         (request base-uri
+                                  :request-method :post
+                                  :body (codec/form-encode {:href        href
+                                                            :redirectURI redirect-uri}))
+                         (ltu/body->edn)
+                         (ltu/is-status 303))
+                id3 (get-in resp [:response :body :resource-id])
+                uri3 (-> resp
+                         (ltu/location))
+                abs-uri3 (str p/service-context id3)]
 
             ;; redirect URLs in location header should contain the client ID and resource id
             (is (re-matches #".*FAKE_CLIENT_ID.*" (or uri "")))
             (is (re-matches (re-pattern (str ".*" (codec/url-encode id) ".*")) (or uri "")))
             (is (re-matches #".*FAKE_CLIENT_ID.*" (or uri2 "")))
             (is (re-matches (re-pattern (str ".*" (codec/url-encode id2) ".*")) (or uri2 "")))
+            (is (re-matches #".*FAKE_CLIENT_ID.*" (or uri3 "")))
+            (is (re-matches (re-pattern (str ".*" (codec/url-encode id3) ".*")) (or uri3 "")))
 
             ;; user should not be able to see session without session role
             (-> session-user
@@ -125,6 +143,10 @@
                 (ltu/is-status 403))
             (-> session-user
                 (request abs-uri2)
+                (ltu/body->edn)
+                (ltu/is-status 403))
+            (-> session-user
+                (request abs-uri3)
                 (ltu/body->edn)
                 (ltu/is-status 403))
 
@@ -168,6 +190,15 @@
                 (ltu/is-operation-present "delete")
                 (ltu/is-operation-present (:validate c/action-uri))
                 (ltu/is-operation-absent "edit"))
+            (-> session-user
+                (header authn-info-header (str "user USER ANON " id3))
+                (request abs-uri3)
+                (ltu/body->edn)
+                (ltu/is-status 200)
+                (ltu/is-id id3)
+                (ltu/is-operation-present "delete")
+                (ltu/is-operation-present (:validate c/action-uri))
+                (ltu/is-operation-absent "edit"))
 
             ;; user query with session role should succeed but and have one entry
             (-> session-user
@@ -182,12 +213,19 @@
                 (ltu/body->edn)
                 (ltu/is-status 200)
                 (ltu/is-count 1))
+            (-> session-user
+                (header authn-info-header (str "user USER ANON " id3))
+                (request base-uri)
+                (ltu/body->edn)
+                (ltu/is-status 200)
+                (ltu/is-count 1))
 
             ;;
             ;; test validation callback
             ;;
             (let [validate-url (str abs-uri "/validate")
-                  validate-url2 (str abs-uri2 "/validate")]
+                  validate-url2 (str abs-uri2 "/validate")
+                  validate-url3 (str abs-uri3 "/validate")]
 
               ;; try hitting the callback with an invalid server configuration
               (with-redefs [environ.core/env {}]
@@ -204,6 +242,13 @@
                              :request-method :get)
                     (ltu/body->edn)
                     (ltu/message-matches #".*missing client ID, base URL, or public key.*")
+                    (ltu/is-status 500))
+
+                (-> session-anon
+                    (request validate-url3
+                             :request-method :get)
+                    (ltu/body->edn)
+                    (ltu/message-matches #".*missing client ID, base URL, or public key.*")
                     (ltu/is-status 500)))
 
               ;; try hitting the callback without the OIDC code parameter
@@ -216,6 +261,13 @@
 
               (-> session-anon
                   (request validate-url2
+                           :request-method :get)
+                  (ltu/body->edn)
+                  (ltu/message-matches #".*not contain required code.*")
+                  (ltu/is-status 400))
+
+              (-> session-anon
+                  (request validate-url3
                            :request-method :get)
                   (ltu/body->edn)
                   (ltu/message-matches #".*not contain required code.*")
@@ -270,7 +322,20 @@
                       claims (if token (sign/unsign-claims token) {})]
                   (is (= location redirect-uri))
                   (is (= "MATCHED_USER" (:username claims)))
-                  (is (re-matches (re-pattern (str ".*" id2 ".*")) (or (:roles claims) ""))))))
+                  (is (re-matches (re-pattern (str ".*" id2 ".*")) (or (:roles claims) ""))))
+
+                (let [ring-info (-> session-anon
+                                    (request (str validate-url3 "?code=GOOD")
+                                             :request-method :get)
+                                    (ltu/body->edn)
+                                    (ltu/is-status 303)
+                                    (ltu/is-set-cookie))
+                      location (ltu/location ring-info)
+                      token (get-in ring-info [:response :cookies "com.sixsq.slipstream.cookie" :value :token])
+                      claims (if token (sign/unsign-claims token) {})]
+                  (is (= location redirect-uri))
+                  (is (= "MATCHED_USER" (:username claims)))
+                  (is (re-matches (re-pattern (str ".*" id3 ".*")) (or (:roles claims) ""))))))
 
             ;; check that the session has been updated
             (let [ring-info (-> session-user
@@ -287,17 +352,30 @@
               (is (not= (:created session) (:updated session))))
 
             (let [ring-info (-> session-user
-                                  (header authn-info-header (str "user USER ANON " id2))
-                                  (request abs-uri2)
-                                  (ltu/body->edn)
-                                  (ltu/is-status 200)
-                                  (ltu/is-id id2)
-                                  (ltu/is-operation-present "delete")
-                                  (ltu/is-operation-absent (:validate c/action-uri))
-                                  (ltu/is-operation-absent "edit"))
-                    session (get-in ring-info [:response :body])]
-                (is (= "MATCHED_USER" (:username session)))
-                (is (not= (:created session) (:updated session))))
+                                (header authn-info-header (str "user USER ANON " id2))
+                                (request abs-uri2)
+                                (ltu/body->edn)
+                                (ltu/is-status 200)
+                                (ltu/is-id id2)
+                                (ltu/is-operation-present "delete")
+                                (ltu/is-operation-absent (:validate c/action-uri))
+                                (ltu/is-operation-absent "edit"))
+                  session (get-in ring-info [:response :body])]
+              (is (= "MATCHED_USER" (:username session)))
+              (is (not= (:created session) (:updated session))))
+
+            (let [ring-info (-> session-user
+                                (header authn-info-header (str "user USER ANON " id3))
+                                (request abs-uri3)
+                                (ltu/body->edn)
+                                (ltu/is-status 200)
+                                (ltu/is-id id3)
+                                (ltu/is-operation-present "delete")
+                                (ltu/is-operation-absent (:validate c/action-uri))
+                                (ltu/is-operation-absent "edit"))
+                  session (get-in ring-info [:response :body])]
+              (is (= "MATCHED_USER" (:username session)))
+              (is (not= (:created session) (:updated session))))
 
             ;; user with session role can delete resource
             (-> session-user
@@ -310,6 +388,13 @@
             (-> session-user
                 (header authn-info-header (str "user USER ANON " id2))
                 (request abs-uri2
+                         :request-method :delete)
+                (ltu/is-unset-cookie)
+                (ltu/body->edn)
+                (ltu/is-status 200))
+            (-> session-user
+                (header authn-info-header (str "user USER ANON " id3))
+                (request abs-uri3
                          :request-method :delete)
                 (ltu/is-unset-cookie)
                 (ltu/body->edn)

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_test.clj
@@ -3,7 +3,7 @@
     [clojure.test :refer :all]
     [com.sixsq.slipstream.ssclj.resources.session :as t]))
 
-(deftest check-is-conent-type?
+(deftest check-is-content-type?
   (are [expected-fn input] (expected-fn (t/is-content-type? input))
                            true? :content-type
                            true? "content-type"

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_test.clj
@@ -1,0 +1,25 @@
+(ns com.sixsq.slipstream.ssclj.resources.session-test
+  (:require
+    [clojure.test :refer :all]
+    [com.sixsq.slipstream.ssclj.resources.session :as t]))
+
+(deftest check-is-conent-type?
+  (are [expected-fn input] (expected-fn (t/is-content-type? input))
+                           true? :content-type
+                           true? "content-type"
+                           true? "Content-Type"
+                           true? "CONTENT-TYPE"
+                           true? "CoNtEnT-TyPe"
+                           false? 1234
+                           false? nil))
+
+(deftest check-is-form?
+  (are [expected-fn input] (expected-fn (t/is-form? input))
+                        true? {:content-type t/form-urlencoded}
+                        true? {"content-type" t/form-urlencoded}
+                        false? {:content-type "application/json"}
+                        false? {"content-type" "application/json"}))
+
+(deftest check-convert-form
+  (is (= {:sessionTemplate {:alpha "alpha", :beta "beta"}}
+         (t/convert-form {:alpha "alpha", "beta" "beta"}))))


### PR DESCRIPTION
Allow creation of sessions with url-encoded input, needed for support from browser clients.