### PR TITLE
add password and hidden parameter types

### DIFF
--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/ParameterType.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/ParameterType.java
@@ -9,9 +9,9 @@ package com.sixsq.slipstream.persistence;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,5 +28,6 @@ public enum ParameterType {
 	Dummy, // not used anymore
 	Enum,
 	RestrictedString,
-	RestrictedText
+	RestrictedText,
+	Hidden
 }

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/credential_template_username_password.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/credential_template_username_password.clj
@@ -32,15 +32,15 @@
   (merge p/CredentialTemplateDescription
          {:username {:displayName "Username"
                      :category    "general"
-                     :description "username"
+                     :description "username of your account"
                      :type        "string"
                      :mandatory   true
                      :readOnly    false
                      :order       1}
           :password {:displayName "Password"
                      :category    "general"
-                     :description "password"
-                     :type        "string"
+                     :description "password for your account"
+                     :type        "password"
                      :mandatory   true
                      :readOnly    false
                      :order       2}}))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/session_template.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/session_template.clj
@@ -92,13 +92,20 @@
 
 (def SessionTemplateDescription
   (merge c/CommonParameterDescription
-         {:method {:displayName "Authentication Method"
-                   :category    "general"
-                   :description "method to be used to authenticate user"
-                   :type        "string"
-                   :mandatory   true
-                   :readOnly    true
-                   :order       0}}))
+         {:method      {:displayName "Authentication Method"
+                        :category    "general"
+                        :description "method to be used to authenticate user"
+                        :type        "string"
+                        :mandatory   true
+                        :readOnly    true
+                        :order       0}
+          :redirectURI {:displayName "Redirect URI"
+                        :category    "general"
+                        :description "optional redirect URI to be used on success"
+                        :type        "hidden"
+                        :mandatory   false
+                        :readOnly    false
+                        :order       1}}))
 ;;
 ;; multimethods for validation
 ;;

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/session_template_github.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/session_template_github.clj
@@ -24,7 +24,7 @@
          {:redirectURI {:displayName "Redirect URI"
                         :category    "general"
                         :description "Redirect URI"
-                        :type        "string"
+                        :type        "hidden"
                         :mandatory   false
                         :readOnly    false
                         :order       1}}))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/session_template_internal.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/session_template_internal.clj
@@ -34,7 +34,7 @@
           :password {:displayName "Password"
                      :category    "general"
                      :description "password"
-                     :type        "string"
+                     :type        "password"
                      :mandatory   true
                      :readOnly    false
                      :order       2}}))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/session_template_oidc.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/session_template_oidc.clj
@@ -24,7 +24,7 @@
          {:redirectURI {:displayName "Redirect URI"
                         :category    "general"
                         :description "Redirect URI"
-                        :type        "string"
+                        :type        "hidden"
                         :mandatory   false
                         :readOnly    false
                         :order       1}}))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/description.cljc
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/description.cljc
@@ -15,7 +15,7 @@
 (s/def :cimi.desc/displayName :cimi.core/nonblank-string)
 (s/def :cimi.desc/category :cimi.core/nonblank-string)
 (s/def :cimi.desc/description :cimi.core/nonblank-string)
-(s/def :cimi.desc/type #{"string" "boolean" "int" "float" "timestamp" "enum" "map" "list"})
+(s/def :cimi.desc/type #{"string" "boolean" "int" "float" "timestamp" "enum" "password" "hidden" "map" "list"})
 (s/def :cimi.desc/mandatory boolean?)
 (s/def :cimi.desc/readOnly boolean?)
 (s/def :cimi.desc/order nat-int?)

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/session_template.cljc
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/session_template.cljc
@@ -9,6 +9,10 @@
 ;; All session resources must have a 'method' attribute.
 (s/def :cimi.session-template/method :cimi.core/identifier)
 
+;; Sessions may provide a redirect URI to be used on successful authentication.
+(s/def :cimi.session-template/redirectURI :cimi.core/nonblank-string)
+
+;; Restrict the href used to create sessions.
 (def session-template-regex #"^session-template/[a-z]+(-[a-z]+)*$")
 (s/def :cimi.session-template/href (s/and string? #(re-matches session-template-regex %)))
 
@@ -18,7 +22,8 @@
 ;; is no sense in defining map resources for the resource itself.
 ;;
 
-(def session-template-keys-spec {:req-un [:cimi.session-template/method]})
+(def session-template-keys-spec {:req-un [:cimi.session-template/method]
+                                 :opt-un [:cimi.session-template/redirectURI]})
 
 (def resource-keys-spec
   (su/merge-keys-specs [c/common-attrs session-template-keys-spec]))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/session_template_github.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/session_template_github.clj
@@ -9,23 +9,15 @@
 ;; the moment.  This will have to change to allow multiple OIDC servers to
 ;; be supported.
 
-(s/def :cimi.session-template.github/redirectURI :cimi.core/nonblank-string)
-
-;; all parameters must be specified in both the template and the create resource
-(def session-template-keys-spec-opt
-  {:opt-un [:cimi.session-template.github/redirectURI]})
-
 ;; Defines the contents of the github SessionTemplate resource itself.
 (s/def :cimi/session-template.github
-  (su/only-keys-maps ps/resource-keys-spec
-                     session-template-keys-spec-opt))
+  (su/only-keys-maps ps/resource-keys-spec))
 
 ;; Defines the contents of the github template used in a create resource.
 ;; NOTE: The name must match the key defined by the resource, :sessionTemplate here.
 (s/def :cimi.session-template.github/sessionTemplate
-  (su/only-keys-maps ps/template-keys-spec
-                     session-template-keys-spec-opt))
+  (su/only-keys-maps ps/template-keys-spec))
 
 (s/def :cimi/session-template.github-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:opt-un [:cimi.session-template.github/sessionTemplate]}))
+                     {:req-un [:cimi.session-template.github/sessionTemplate]}))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/session_template_internal.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/session_template_internal.clj
@@ -25,4 +25,4 @@
 
 (s/def :cimi/session-template.internal-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:opt-un [:cimi.session-template.internal/sessionTemplate]}))
+                     {:req-un [:cimi.session-template.internal/sessionTemplate]}))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/session_template_oidc.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/session_template_oidc.clj
@@ -5,27 +5,19 @@
     [com.sixsq.slipstream.ssclj.resources.spec.session-template :as ps]))
 
 ;; Parameters for the OpenID Connect endpoint, credentials, etc. are picked
-;; up from the environment.  Consequently, so parameters are necessary at
+;; up from the environment.  Consequently, no parameters are necessary at
 ;; the moment.  This will have to change to allow multiple OIDC servers to
 ;; be supported.
 
-(s/def :cimi.session-template.oidc/redirectURI :cimi.core/nonblank-string)
-
-;; all parameters must be specified in both the template and the create resource
-(def session-template-keys-spec-opt
-  {:opt-un [:cimi.session-template.oidc/redirectURI]})
-
 ;; Defines the contents of the oidc SessionTemplate resource itself.
 (s/def :cimi/session-template.oidc
-  (su/only-keys-maps ps/resource-keys-spec
-                     session-template-keys-spec-opt))
+  (su/only-keys-maps ps/resource-keys-spec))
 
 ;; Defines the contents of the oidc template used in a create resource.
 ;; NOTE: The name must match the key defined by the resource, :sessionTemplate here.
 (s/def :cimi.session-template.oidc/sessionTemplate
-  (su/only-keys-maps ps/template-keys-spec
-                     session-template-keys-spec-opt))
+  (su/only-keys-maps ps/template-keys-spec))
 
 (s/def :cimi/session-template.oidc-create
   (su/only-keys-maps ps/create-keys-spec
-                     {:opt-un [:cimi.session-template.oidc/sessionTemplate]}))
+                     {:req-un [:cimi.session-template.oidc/sessionTemplate]}))


### PR DESCRIPTION
Password and hidden parameter types are needed to help the clients decide which parameters to make visible to users.  

Connected to SixSq/tasklist#1138. 
