### PR TITLE
allow anon users

### DIFF
--- a/db-binding/src/com/sixsq/slipstream/db/es/acl.clj
+++ b/db-binding/src/com/sixsq/slipstream/db/es/acl.clj
@@ -57,9 +57,9 @@
 
 (defn and-acl
   "Enriches query-builder by adding a clause on ACL (extracted from options)"
-  [query-builder options]
-  (let [user-name-clause (when-let [user-name (:user-name options)] [[(name acl-users) user-name]])
-        user-roles-clauses (map vector (repeat (name acl-roles)) (:user-roles options))
+  [query-builder {:keys [user-name user-roles] :as options}]
+  (let [user-name-clause (when user-name [[(name acl-users) user-name]])
+        user-roles-clauses (map vector (repeat (name acl-roles)) user-roles)
         acl-clauses (concat user-name-clause user-roles-clauses)
         acl-queries (map (fn [[field value]] (ef/term-query field value)) acl-clauses)
         query-acl (if (empty? acl-queries) query-no-result (ef/or-query acl-queries))]

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/middleware/authn_info_header.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/middleware/authn_info_header.clj
@@ -54,21 +54,23 @@
     (extract-authn-info request)
     (cookies/extract-cookie-info (request-cookies request))))
 
+(defn add-anon-role [roles]
+  (vec (conj (set roles) "ANON")))
+
 (defn create-identity-map
   [[username roles]]
-  (if username
-    (let [id-map (if (seq roles) {:roles roles} {})
-          id-map (assoc id-map :identity username)]
-      {:current         username
-       :authentications {username id-map}})
-    {}))
+  (let [current (or username "ANON")
+        authn-roles (add-anon-role roles)
+        id-map (cond-> {:roles authn-roles}
+                       username (assoc :identity username))]
+    {:current         current
+     :authentications {current id-map}}))
 
 (defn add-user-name-roles
   [request]
   (let [[username roles] (extract-info request)]
-    (-> request
-        (assoc :user-name username)
-        (assoc :user-roles roles))))
+    (cond-> (assoc request :user-roles (add-anon-role roles))
+            username (assoc :user-name username))))
 
 (defn add-claims
   [request]

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/common/authz.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/common/authz.clj
@@ -24,7 +24,7 @@
   "Extracts the current authentication (identity map) from the ring
    request.  Returns nil if there is no current identity."
   [{{:keys [current authentications]} :identity}]
-  (get authentications current))
+  (or (get authentications current) {:identifier nil, :roles ["ANON"]}))
 
 (defn extract-right
   "Given the identity map, this extracts the associated right from the


### PR DESCRIPTION
Connected to #1041.

Add the "ANON" role when treating requests; add this role even for unauthenticated requests.  This is necessary to allow authentication resources to be visible to users that are not logged in.
