### PR TITLE
do not allow created users to be renamed

### DIFF
--- a/auth/test/com/sixsq/slipstream/auth/external_test.clj
+++ b/auth/test/com/sixsq/slipstream/auth/external_test.clj
@@ -95,7 +95,13 @@
     (is (= 1 (count users))))
   (is (= "missing" (create-user-when-missing! {:authn-login "missing", :email "ok@example.com"})))
   (let [users (kc/select db/users)]
-    (is (= 2 (count users)))))
+    (is (= 2 (count users))))
+  (is (= "deleted" (create-user-when-missing! {:authn-login "deleted", :email "ok@example.com", :state "DELETED"})))
+  (let [users (kc/select db/users)]
+    (is (= 3 (count users))))
+  (is (nil? (create-user-when-missing! {:authn-login "deleted", :email "ok@example.com", :fail-on-existing? true})))
+  (let [users (kc/select db/users)]
+    (is (= 3 (count users)))))
 
 (deftest test-sanitize-login-name
   (is (= "st" (sanitize-login-name "st")))

--- a/auth/test/com/sixsq/slipstream/auth/utils/db_test.clj
+++ b/auth/test/com/sixsq/slipstream/auth/utils/db_test.clj
@@ -69,7 +69,19 @@
   (th/add-user-for-test! {:username "stef" :password "secret"})
   (is (= "stef_1" (db/create-user! "github" "stef" "st@s.com")))
   (let [users-created (kc/select db/users)]
-    (is (= 2 (count users-created)))))
+    (is (= 2 (count users-created))))
+  (is (nil? (db/create-user! {:authn-login "stef"
+                              :password "secret"
+                              :email "st@s.com"
+                              :fail-on-existing? true})))
+  (let [users-created (kc/select db/users)]
+    (is (= 2 (count users-created))))
+  (is (= "stef_2" (db/create-user! {:authn-login "stef"
+                                    :password "secret"
+                                    :email "st@s.com"
+                                    :fail-on-existing? false})))
+  (let [users-created (kc/select db/users)]
+    (is (= 3 (count users-created)))))
 
 (deftest test-name-no-collision
   (is (= "_" (db/name-no-collision "_" [])))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/session_oidc/utils.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/session_oidc/utils.clj
@@ -66,6 +66,9 @@
 (defn throw-invalid-access-code [msg redirectURI]
   (logu/log-error-and-throw-with-redirect 400 (str "error when processing OIDC access token: " msg) redirectURI))
 
+(defn throw-inactive-user [username redirectURI]
+  (logu/log-error-and-throw-with-redirect 400 (str "account is inactive (" username ")") redirectURI))
+
 ;; retrieval of configuration parameters
 
 (defn config-params


### PR DESCRIPTION
When creating users from external OIDC servers, do not allow the username to be changed to avoid conflicts with existing, deleted or inactive users.