### PR TITLE
update schema for acl principals

### DIFF
--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/common.cljc
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/common.cljc
@@ -105,10 +105,11 @@
 ;; these definitions are the 'cimi.acl' namespace
 ;;
 
-;; A principal consists of words containing letters and digits, separated by
-;; underscores, dashes, slashes, or dots.
+;; A principal is a sequence of characters starting with a letter or digit and
+;; containing any number of letters, digits, slashes, dots, colons, underscores,
+;; or dashes.
 (s/def :cimi.acl/principal
-  (su/regex-string #"[a-zA-Z0-9/\._-]" #"^[a-zA-Z0-9]+([/\._-][a-zA-Z0-9]+)*$"))
+  (su/regex-string #"[a-zA-Z0-9/\.:_-]" #"^[a-zA-Z0-9]+[a-zA-Z0-9/\.:_-]*$"))
 
 (s/def :cimi.acl/type #{"USER" "ROLE"})
 (s/def :cimi.acl/right #{"ALL" "VIEW" "MODIFY"})

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/spec/common_test.cljc
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/spec/common_test.cljc
@@ -60,6 +60,25 @@
                        false? {"ok" 1}
                        false? [:bad "bad"]))
 
+(deftest check-principal
+  (are [expect-fn arg] (expect-fn (s/valid? :cimi.acl/principal arg))
+                       true? "A"
+                       true? "A.B-C/D_E:F"
+                       true? "A.B-C/D_E:F"
+                       true? "0..1--2//3__4::5"
+                       true? "http://example.org/group"
+                       true? "1."
+                       true? "2-"
+                       true? "3/"
+                       true? "4_"
+                       true? "5:"
+                       false? ".1"
+                       false? "-2"
+                       false? "/3"
+                       false? "_4"
+                       false? ":5"
+                       false? "NO WHITESPACE"))
+
 (deftest check-owner
   (let [id {:principal "ADMIN", :type "ROLE"}]
     (are [expect-fn arg] (expect-fn (s/valid? :cimi.acl/owner arg))


### PR DESCRIPTION
Allow principals like "realm:role". 

Connected to SixSq/tasklist#1201. 