### PR TITLE
add missing authn resources

### DIFF
--- a/rpm/pom.xml
+++ b/rpm/pom.xml
@@ -453,6 +453,21 @@
             </mapping>
 
             <mapping>
+              <directory>/opt/slipstream/authn</directory>
+              <filemode>644</filemode>
+              <directoryIncluded>false</directoryIncluded>
+              <sources>
+                <source>
+                  <location>target/authn</location>
+                  <excludes>
+                    <exclude>META-INF</exclude>
+                    <exclude>META-INF/**/*</exclude>
+                  </excludes>
+                </source>
+              </sources>
+            </mapping>
+
+            <mapping>
               <directory>${installation.dir}</directory>
               <filemode>664</filemode>
               <configuration>true</configuration>


### PR DESCRIPTION
The authn resource were not being added to the RPM package.  Add them. 

