### PR TITLE
fix ring-core dependency conflict

### DIFF
--- a/db-binding/build.boot
+++ b/db-binding/build.boot
@@ -43,6 +43,14 @@
                    [ring/ring-json]
                    [superstring]
 
+                   ;;
+                   ;; This dependency is included explicitly to avoid having
+                   ;; ring/ring-json pull in an old version of ring-core that
+                   ;; conflicts with the more recent one.
+                   ;; 
+                   [ring/ring-core]
+
+
                    ;; boot tasks
                    [boot-environ]
                    [adzerk/boot-test]


### PR DESCRIPTION
Fix a dependency conflict between the version of ring-core used by db-binding and that used elsewhere in the server.
