### PR TITLE
Ensure module version atomicity

### DIFF
--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/VersionCounter.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/VersionCounter.java
@@ -22,18 +22,15 @@ package com.sixsq.slipstream.persistence;
 
 import java.io.Serializable;
 
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @SuppressWarnings("serial")
 @Entity
 public class VersionCounter implements Serializable {
 
 	private static int ID = 1;
-	
-	public static int getNextVersion() {
+
+	synchronized static int getNextVersion() {
 		EntityManager em = PersistenceUtil.createEntityManager();
 		EntityTransaction transaction = em.getTransaction();
 		transaction.begin();

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/util/SerializationUtil.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/util/SerializationUtil.java
@@ -23,6 +23,8 @@ package com.sixsq.slipstream.util;
 import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -47,6 +49,8 @@ import com.sixsq.slipstream.persistence.Metadata;
 import com.sixsq.slipstream.persistence.Run;
 
 public class SerializationUtil {
+
+	private static Logger logger = Logger.getLogger(SerializationUtil.class.getName());
 
 	public static Metadata fromXml(String contents,
 			Class<? extends Metadata> resultClass)
@@ -73,8 +77,9 @@ public class SerializationUtil {
 			return writer.toString();
 
 		} catch (Exception e) {
-			throw new SlipStreamInternalException(
-					"cannot serialize object to string, with detail: " + e.getMessage(), e);
+			String message = "cannot serialize object to string, with detail: ";
+			logger.log(Level.SEVERE, message, e);
+			throw new SlipStreamInternalException(message + e.getMessage(), e);
 		} finally {
 			toXmlStringTimer.stop();
 			writer.close();

--- a/jar-persistence/src/test/java/com/sixsq/slipstream/persistence/VersionCounterTest.java
+++ b/jar-persistence/src/test/java/com/sixsq/slipstream/persistence/VersionCounterTest.java
@@ -22,14 +22,53 @@ package com.sixsq.slipstream.persistence;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
 public class VersionCounterTest {
+
+	private static final int numberOfThreads = 30;
 
 	@Test
 	public void increment() {
 		int counter = VersionCounter.getNextVersion();
+
 		assertThat(VersionCounter.getNextVersion(), is(counter+1));
+		assertThat(VersionCounter.getNextVersion(), is(counter+2));
+	}
+
+	@Test
+	public void testParallelIncrement() throws InterruptedException {
+		List<Thread> threads = new ArrayList<>();
+
+		int initialVersion = VersionCounter.getNextVersion();
+		int finalVersion = initialVersion + numberOfThreads + 1;
+
+		for (int i = 1; i <= numberOfThreads; i++) {
+			Thread thread = new Thread(new IncrementVersionRunnable());
+			threads.add(thread);
+		}
+
+		for (Thread thread : threads) {
+			thread.start();
+		}
+
+		for (Thread thread : threads) {
+			thread.join();
+		}
+
+		assertThat(VersionCounter.getNextVersion(), is(finalVersion));
+	}
+
+	public class IncrementVersionRunnable implements Runnable {
+
+		@Override
+		public void run() {
+			VersionCounter.getNextVersion();
+		}
+
 	}
 }

--- a/jar-persistence/src/test/java/com/sixsq/slipstream/persistence/VersionCounterTest.java
+++ b/jar-persistence/src/test/java/com/sixsq/slipstream/persistence/VersionCounterTest.java
@@ -44,8 +44,8 @@ public class VersionCounterTest {
 	public void testParallelIncrement() throws InterruptedException {
 		List<Thread> threads = new ArrayList<>();
 
-		int initialVersion = VersionCounter.getNextVersion();
-		int finalVersion = initialVersion + numberOfThreads + 1;
+		final int initialVersion = VersionCounter.getNextVersion();
+		final int finalVersion = initialVersion + numberOfThreads + 1;
 
 		for (int i = 1; i <= numberOfThreads; i++) {
 			Thread thread = new Thread(new IncrementVersionRunnable());


### PR DESCRIPTION
It doesn't ensure atomicity if SlipStream is scaled horizontally.
In the latter case the atomicity should be provided by the database.

Connected to #1135 

