### PR TITLE
fix memory leak when using elasticsearch client

### DIFF
--- a/db-binding/src/com/sixsq/slipstream/db/es/es_binding.clj
+++ b/db-binding/src/com/sixsq/slipstream/db/es/es_binding.clj
@@ -14,7 +14,7 @@
 
 (def ^:const index-name "resources-index")
 
-(defn- wait-client-create-index
+(defn wait-client-create-index
   [client]
   (esu/wait-for-cluster client)
   (when-not (esu/index-exists? client index-name)
@@ -25,10 +25,6 @@
 (defn create-client
   []
   (wait-client-create-index (esu/create-es-client)))
-
-(defn create-test-client
-  []
-  (wait-client-create-index (esu/create-test-es-client)))
 
 (def ^:dynamic *client*)
 

--- a/db-binding/src/com/sixsq/slipstream/db/es/es_util.clj
+++ b/db-binding/src/com/sixsq/slipstream/db/es/es_util.clj
@@ -215,7 +215,9 @@
 
 (defn create-test-es-client
   []
-  (node-client (create-test-node)))
+  (let [node (create-test-node)
+        client (node-client node)]
+    [client node]))
 
 (defn wait-for-cluster
   [^Client client]

--- a/db-binding/src/com/sixsq/slipstream/db/es/javawrapper.clj
+++ b/db-binding/src/com/sixsq/slipstream/db/es/javawrapper.clj
@@ -9,6 +9,7 @@
 
 (defn -createInmemEsDb
   []
-  (esb/set-client! (esb/create-test-client))
-  (db/set-impl! (esb/get-instance))
-  (esu/reset-index esb/*client* esb/index-name))
+  (let [[client node] (esb/create-client)]
+    (esb/set-client! client)                                ;; NOTE: client and node are not closed!
+    (db/set-impl! (esb/get-instance))
+    (esu/reset-index esb/*client* esb/index-name)))

--- a/db-binding/test/com/sixsq/slipstream/db/es/es_util_test.clj
+++ b/db-binding/test/com/sixsq/slipstream/db/es/es_util_test.clj
@@ -4,4 +4,6 @@
     [com.sixsq.slipstream.db.es.es-util :as eu]))
 
 (deftest test-create-test-es-client
-  (is (not (nil? (eu/create-test-es-client)))))
+  (let [[client node] (eu/create-test-es-client)]
+    (is (not (nil? client)))
+    (is (not (nil? node)))))

--- a/db-serializers/build.boot
+++ b/db-serializers/build.boot
@@ -44,6 +44,7 @@
                     [boot-environ]
                     [adzerk/boot-test]
                     [adzerk/boot-reload]
+                    [onetom/boot-lein-generate]
                     [tolitius/boot-check]]))))
 
 (require
@@ -53,7 +54,8 @@
   '[tolitius.boot-check :refer [with-yagni
                                 with-eastwood
                                 with-kibit
-                                with-bikeshed]])
+                                with-bikeshed]]
+  '[boot.lein :refer [generate]])
 
 (set-env!
   :source-paths #{"test"}

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/accounting_record_obj_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/accounting_record_obj_lifecycle_test.clj
@@ -13,7 +13,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [clojure.spec.alpha :as s]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase acc/resource-url)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/accounting_record_vm_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/accounting_record_vm_lifecycle_test.clj
@@ -13,7 +13,7 @@
       [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
       [clojure.spec.alpha :as s]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase acc/resource-url)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/cloud_entry_point_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/cloud_entry_point_lifecycle_test.clj
@@ -9,7 +9,7 @@
     [com.sixsq.slipstream.ssclj.app.params :as p]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/configuration_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/configuration_lifecycle_test.clj
@@ -8,7 +8,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.dynamic-load :as dyn]
     [com.sixsq.slipstream.ssclj.resources.configuration-lifecycle-test-utils :as test-utils]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 ;; initialize must to called to pull in ConfigurationTemplate test examples
 (dyn/initialize)

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/configuration_template_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/configuration_template_lifecycle_test.clj
@@ -18,7 +18,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.debug-utils :as du]
     [com.sixsq.slipstream.ssclj.resources.configuration-template-lifecycle-test-utils :as test-utils]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/configuration_template_lifecycle_test_utils.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/configuration_template_lifecycle_test_utils.clj
@@ -15,7 +15,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.schema :as c]
     [com.sixsq.slipstream.ssclj.resources.common.debug-utils :as du]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/connector_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/connector_lifecycle_test.clj
@@ -15,7 +15,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.debug-utils :as du]
     [com.sixsq.slipstream.ssclj.resources.common.crud :as crud]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/connector_template_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/connector_template_lifecycle_test.clj
@@ -16,7 +16,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.debug-utils :as du])
   (:import (clojure.lang ExceptionInfo)))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/credential_ssh_public_key_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/credential_ssh_public_key_lifecycle_test.clj
@@ -16,7 +16,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [clojure.spec.alpha :as s]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase credential/resource-url)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/credential_template_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/credential_template_lifecycle_test.clj
@@ -15,7 +15,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [com.sixsq.slipstream.ssclj.resources.common.schema :as c]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase ct/resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/credential_username_password_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/credential_username_password_lifecycle_test.clj
@@ -16,7 +16,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [clojure.spec.alpha :as s]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase credential/resource-url)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/event_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/event_test.clj
@@ -42,7 +42,7 @@
 
 (defn fixture-insert-some-events
   [f]
-  (ltu/with-test-client
+  (ltu/with-test-es-client
     (insert-some-events)
     (f)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/service_attribute_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/service_attribute_lifecycle_test.clj
@@ -11,7 +11,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [com.sixsq.slipstream.ssclj.resources.service-attribute-namespace :as san]))
 
-(use-fixtures :each t/with-test-client-fixture)
+(use-fixtures :each t/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/service_attribute_namespace_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/service_attribute_namespace_lifecycle_test.clj
@@ -10,7 +10,7 @@
     [com.sixsq.slipstream.ssclj.app.params :as p]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]))
 
-(use-fixtures :each t/with-test-client-fixture)
+(use-fixtures :each t/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context resource-url))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/service_offer_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/service_offer_lifecycle_test.clj
@@ -12,7 +12,7 @@
     [com.sixsq.slipstream.ssclj.app.params :as p]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]))
 
-(use-fixtures :each t/with-test-client-fixture)
+(use-fixtures :each t/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context resource-url))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_cyclone_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_cyclone_lifecycle_test.clj
@@ -23,7 +23,7 @@
     [com.sixsq.slipstream.ssclj.resources.session-template :as st]
     [com.sixsq.slipstream.ssclj.resources.configuration :as configuration]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase session/resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_github_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_github_lifecycle_test.clj
@@ -23,7 +23,7 @@
     [com.sixsq.slipstream.ssclj.resources.session-template :as st]
     [com.sixsq.slipstream.ssclj.resources.configuration :as configuration]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase session/resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_internal_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_internal_lifecycle_test.clj
@@ -19,7 +19,7 @@
     [com.sixsq.slipstream.auth.utils.sign :as sign]
     [com.sixsq.slipstream.ssclj.resources.session-template :as st]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase session/resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_oidc_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_oidc_lifecycle_test.clj
@@ -23,7 +23,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.schema :as c]
     [com.sixsq.slipstream.ssclj.resources.session-template :as st]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase session/resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_template_cyclone_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_template_cyclone_lifecycle_test.clj
@@ -11,7 +11,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [com.sixsq.slipstream.ssclj.resources.session-template-lifecycle-test-utils :as stu]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase st/resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_template_github_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_template_github_lifecycle_test.clj
@@ -11,7 +11,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [com.sixsq.slipstream.ssclj.resources.session-template-lifecycle-test-utils :as stu]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase st/resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_template_internal_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_template_internal_lifecycle_test.clj
@@ -10,7 +10,7 @@
     [com.sixsq.slipstream.ssclj.resources.session-template-lifecycle-test-utils :as stu]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase st/resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_template_oidc_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/session_template_oidc_lifecycle_test.clj
@@ -11,7 +11,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [com.sixsq.slipstream.ssclj.resources.session-template-lifecycle-test-utils :as stu]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase st/resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/usage_event_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/usage_event_test.clj
@@ -18,7 +18,7 @@
     [com.sixsq.slipstream.ssclj.usage.record-keeper :as rk]
     [com.sixsq.slipstream.ssclj.resources.usage-record :as ur]))
 
-(use-fixtures :each t/with-test-client-fixture)
+(use-fixtures :each t/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/usage_record_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/usage_record_test.clj
@@ -20,7 +20,7 @@
     [com.sixsq.slipstream.ssclj.usage.record-keeper :as rc]
     [com.sixsq.slipstream.db.es.es-util :as esu]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/usage_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/usage_test.clj
@@ -25,7 +25,7 @@
 
 (defn insert-daily-summaries
   [f]
-  (ltu/with-test-client
+  (ltu/with-test-es-client
     (rc/insert-summary! (summary "joe" "exo" :daily [2015 04 16] {:ram {:unit-minutes 100.0}}) {:user-name "joe"})
     (rc/insert-summary! (summary "joe" "exo" :daily [2015 04 17] {:ram {:unit-minutes 200.0}}) {:user-name "joe"})
     (rc/insert-summary! (summary "mike" "aws" :daily [2015 04 18] {:ram {:unit-minutes 500.0}}) {:user-name "mike"})

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/user_auto_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/user_auto_lifecycle_test.clj
@@ -16,7 +16,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [clojure.spec.alpha :as s]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase user/resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/user_direct_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/user_direct_lifecycle_test.clj
@@ -16,7 +16,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [clojure.spec.alpha :as s]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase user/resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/user_template_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/user_template_lifecycle_test.clj
@@ -17,7 +17,7 @@
     [com.sixsq.slipstream.ssclj.resources.common.schema :as c]
     [com.sixsq.slipstream.ssclj.resources.common.debug-utils :as du]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def base-uri (str p/service-context (u/de-camelcase resource-name)))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/usage/summarizer_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/usage/summarizer_test.clj
@@ -5,16 +5,16 @@
     [clj-time.core :as time]
     [clojure.test :refer :all]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (deftest user-summary-without-date
-  (ltu/with-test-client
+  (ltu/with-test-es-client
     (us/do-summarize "-f" "daily")
     (us/do-summarize "-f" "weekly")
     (us/do-summarize "-f" "monthly")))
 
 (deftest user-summary-with-args
-  (ltu/with-test-client
+  (ltu/with-test-es-client
     (us/do-summarize "-d" "2015-01-01" "-f" "daily")
     (us/do-summarize "--date" "2015-01-01" "--frequency" "daily")))
 

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/usage/summary_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/usage/summary_test.clj
@@ -21,7 +21,7 @@
 (def start-april (u/timestamp 2015 04))
 (def start-may (u/timestamp 2015 05))
 
-(use-fixtures :each tu/with-test-client-fixture)
+(use-fixtures :each tu/with-test-es-client-fixture)
 
 (deftest truncate-filters-outside-records
   (let [urs [{:start-timestamp in-day-1 :end-timestamp in-day-2}]]

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/usage/summary_volume_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/usage/summary_volume_test.clj
@@ -9,7 +9,7 @@
     [com.sixsq.slipstream.ssclj.resources.lifecycle-test-utils :as ltu]
     [com.sixsq.slipstream.db.impl :as db]))
 
-(use-fixtures :each ltu/with-test-client-fixture)
+(use-fixtures :each ltu/with-test-es-client-fixture)
 
 (def jack-exoscale
   {


### PR DESCRIPTION
Fix memory leak by closing client/node.  Update function naming to make clear that the create client is an elasticsearch client.

Connected to #1141.