### PR TITLE
fix problem with missing dependency

### DIFF
--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/credential.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/credential.clj
@@ -60,7 +60,7 @@
 
 (defmethod create-validate-subtype :default
   [resource]
-  (logu/log-and-throw-400 "missing or invalid CredentialTemplate reference"))
+  (logu/log-and-throw-400 (str "cannot validate CredentialTemplate create document with type: '" (dispatch-on-registration-method resource) "'")))
 
 (defmethod crud/validate create-uri
   [resource]
@@ -98,7 +98,7 @@
 ;; default implementation throws if the credential type is unknown
 (defmethod tpl->credential :default
   [resource request]
-  (logu/log-and-throw-400 "missing or invalid CredentialTemplate reference"))
+  (logu/log-and-throw-400 (str "cannot transform CredentialTemplate document to template for type: '" (:type resource) "'")))
 
 ;;
 ;; CRUD operations

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/util/namespace_utils.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/util/namespace_utils.clj
@@ -22,8 +22,8 @@
     (require ns-sym)
     (log/info "loaded namespace:" ns-sym)
     (find-ns ns-sym)
-    (catch Exception _
-      (log/error "could not load namespace:" ns-sym)
+    (catch Exception e
+      (log/error "could not load namespace:" ns-sym " ===>>> " (.getMessage e))
       nil)))
 
 (defn load-filtered-namespaces

--- a/ssclj/rpm/pom.xml
+++ b/ssclj/rpm/pom.xml
@@ -187,7 +187,7 @@
             <configuration>
               <outputDirectory>${project.build.directory}/dependency/lib/ext</outputDirectory>
               <excludeArtifactIds>SlipStreamToolsCli-jar</excludeArtifactIds>
-              <stripVersion>true</stripVersion>
+              <stripVersion>false</stripVersion>
               <stripClassifier>true</stripClassifier>
               <excludeTypes>pom</excludeTypes>
               <includeScope>runtime</includeScope>


### PR DESCRIPTION
Connected to #982. 

The resources using bcrypt are failing to load because of a missing dependency.  The problem is that both `clojurewerkz/scrypt` and its dependency `com.lambdaworks/scrypt` generate a jar file named `scrypt.jar`, causing one to be left out of the RPM package.  This PR fixes this, but only by not stripping the versions from the jar files.  This is ugly, but there is no other solution without renaming the core artifacts. 

The PR also includes a couple of enhancements to the logging that were needed to diagnose this problem. 
