### PR TITLE
slipstream-server rpm: consider /etc/default/* as configuration files

### DIFF
--- a/rpm/pom.xml
+++ b/rpm/pom.xml
@@ -523,6 +523,7 @@
 
             <mapping>
               <directory>/etc/default</directory>
+              <configuration>true</configuration>
               <sources>
                 <softlinkSource>
                   <destination>slipstream</destination>


### PR DESCRIPTION
To prevent an update to replace for example the file /etc/default/slipstream which might have been updated by the administrator.