### PR TITLE
change cloud attribute to credential

### DIFF
--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/virtual_machine.cljc
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/virtual_machine.cljc
@@ -4,14 +4,14 @@
     [com.sixsq.slipstream.ssclj.util.spec :as su]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
 
-(s/def :cimi.virtual-machine/cloud :cimi.common/resource-link)
+(s/def :cimi.virtual-machine/credential :cimi.common/resource-link)
 (s/def :cimi.virtual-machine/instanceID :cimi.core/identifier)
 (s/def :cimi.virtual-machine/state :cimi.core/nonblank-string)
 (s/def :cimi.virtual-machine/ip :cimi.core/nonblank-string)
 (s/def :cimi.virtual-machine/serviceOffer :cimi.common/resource-link)
 (s/def :cimi.virtual-machine/run :cimi.common/resource-link)
 
-(def virtual-machine-specs {:req-un [:cimi.virtual-machine/cloud
+(def virtual-machine-specs {:req-un [:cimi.virtual-machine/credential
                                      :cimi.virtual-machine/instanceID
                                      :cimi.virtual-machine/state]
                             :opt-un [:cimi.virtual-machine/run

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/spec/virtual_machine_test.cljc
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/spec/virtual_machine_test.cljc
@@ -38,8 +38,9 @@
                 :state        "Running"
                 :ip           "127.0.0.1"
 
-                :cloud        {:href  "connector/0123-4567-8912",
-                               :roles ["realm:cern", "realm:my-accounting-group"]}
+                :credential   {:href  "connector/0123-4567-8912",
+                               :roles ["realm:cern", "realm:my-accounting-group"]
+                               :users ["long-user-id-1", "long-user-id-2"]}
 
                 :run          {:href "run/aaa-bbb-ccc",
                                :user {:href "user/test"}}
@@ -64,7 +65,7 @@
                        true? (assoc vm-sample :name "name"))
 
   ;; mandatory keywords
-  (doseq [k #{:cloud :state :instanceID}]
+  (doseq [k #{:credential :state :instanceID}]
     (is (not (s/valid? :cimi/virtual-machine (dissoc vm-sample k)))))
 
   ;; optional keywords

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/virtual_machine_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/virtual_machine_lifecycle_test.clj
@@ -81,8 +81,9 @@
                           :ip           "127.0.0.1"
 
 
-                          :cloud        {:href  "connector/0123-4567-8912",
-                                         :roles ["realm:cern", "realm:my-accounting-group"]}
+                          :credential   {:href  "connector/0123-4567-8912",
+                                         :roles ["realm:cern", "realm:my-accounting-group"]
+                                         :users ["long-user-id-1", "long-user-id-2"]}
 
 
                           :run          {:href "run/aaa-bbb-ccc",


### PR DESCRIPTION
There is a conflict in the elasticsearch mapping with the "cloud" attribute.  To avoid this issue while waiting for a more correct solution, change the attribute name to "credential".  There are already mappings for "credential", but the `href`, `roles`, and `users` should not conflict with what is there already.
