### PR TITLE
remove all instrumentation metrics at the ssclj server shutdown

### DIFF
--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/app/server.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/app/server.clj
@@ -8,7 +8,7 @@
     [ring.middleware.nested-params :refer [wrap-nested-params]]
     [ring.middleware.cookies :refer [wrap-cookies]]
 
-    [metrics.core :refer [default-registry]]
+    [metrics.core :refer [default-registry remove-all-metrics]]
     [metrics.ring.instrument :refer [instrument]]
     [metrics.ring.expose :refer [expose-metrics-as-json]]
     [metrics.jvm.core :refer [instrument-jvm]]
@@ -37,8 +37,6 @@
    header treatment, and message formatting."
   []
   (log/info "creating ring handler")
-
-  (instrument-jvm default-registry)
 
   (compojure.core/routes)
 
@@ -71,6 +69,8 @@
    (log/info "java version: " (System/getProperty "java.version"))
    (log/info "java classpath: " (System/getProperty "java.class.path"))
 
+   (instrument-jvm default-registry)
+
    (esb/set-client! (esb/create-client))
 
    (zku/set-client! (zku/create-client))
@@ -97,4 +97,9 @@
   (try
     (esb/close-client!)
     (catch Exception e
-      (log/warn "elasticsearch client close failed:" (.getMessage e)))))
+      (log/warn "elasticsearch client close failed:" (.getMessage e))))
+  (try
+    (remove-all-metrics)
+    (catch Exception e
+      (log/warn "failed removing all instrumentation metrics:" (.getMessage e)))))
+


### PR DESCRIPTION
This exception is no more
```
     java.lang.IllegalArgumentException: A metric named jvm.attribute.vendor already exists
clojure.lang.Compiler$CompilerException: java.lang.IllegalArgumentException: A metric named jvm.attribute.vendor already exists, compiling:(NO_SOURCE_FILE:1:14)
```
and the server restart from the repl works


```
 $ boot server-repl
nREPL server started on port 65415 on host 127.0.0.1 - nrepl://127.0.0.1:65415
REPL-y 0.3.7, nREPL 0.2.12
Clojure 1.9.0-beta2
Java HotSpot(TM) 64-Bit Server VM 1.8.0_45-b14
        Exit: Control+D or (exit) or (quit)
    Commands: (user/help)
        Docs: (doc function-name-here)
              (find-doc "part-of-name-here")
Find by Name: (find-name "part-of-name-here")
      Source: (source function-name-here)
     Javadoc: (javadoc java-object-or-class-here)
    Examples from clojuredocs.org: [clojuredocs or cdoc]
              (user/clojuredocs name-here)
              (user/clojuredocs "ns-here" "name-here")
boot.user=> (require '[com.sixsq.slipstream.ssclj.app.server :as server :reload true])
nil
boot.user=> (def stop-fn (server/start 8201))
#'boot.user/stop-fn
boot.user=> (server/stop stop-fn)
nil
boot.user=> (def stop-fn (server/start 8201))
#'boot.user/stop-fn
boot.user=>
```