### PR TITLE
removed the need to mute SscljProxy by using ssclj+es+zk fixture

### DIFF
--- a/db-binding/src/com/sixsq/slipstream/db/es/binding.clj
+++ b/db-binding/src/com/sixsq/slipstream/db/es/binding.clj
@@ -38,9 +38,8 @@
 
 (defn close-client!
   []
-  (let [client *client*]
-    (alter-var-root #'*client* (constantly client))
-    (.close client)))
+  (.close *client*)
+  (unset-client!))
 
 (defn force-admin-role-right-all
   [data]

--- a/db-binding/test/com/sixsq/slipstream/db/es/binding_test.clj
+++ b/db-binding/test/com/sixsq/slipstream/db/es/binding_test.clj
@@ -1,0 +1,11 @@
+(ns com.sixsq.slipstream.db.es.binding-test
+  (:require
+    [clojure.test :refer :all]
+    [com.sixsq.slipstream.db.es.binding :as eb]))
+
+(deftest test-set-close-es-client
+  (is (instance? clojure.lang.Var$Unbound eb/*client*))
+  (eb/set-client! (java.io.StringWriter.))
+  (is (not (instance? clojure.lang.Var$Unbound eb/*client*)))
+  (eb/close-client!)
+  (is (instance? clojure.lang.Var$Unbound eb/*client*)))

--- a/db-serializers/test/com/sixsq/slipstream/db/serializers/utils_test.clj
+++ b/db-serializers/test/com/sixsq/slipstream/db/serializers/utils_test.clj
@@ -38,3 +38,10 @@
   (is (= false (u/as-boolean "false")))
   (is (= nil (u/as-boolean nil)))
   )
+
+(deftest test-start-stop-es
+  (is (instance? clojure.lang.Var$Unbound u/*es-server*))
+  (u/create-test-es-db-uncond)
+  (is (not (instance? clojure.lang.Var$Unbound u/*es-server*)))
+  (u/close-es-server!)
+  (is (instance? clojure.lang.Var$Unbound u/*es-server*)))

--- a/jar-async/build.boot
+++ b/jar-async/build.boot
@@ -32,13 +32,15 @@
                    [adzerk/boot-test]
                    [adzerk/boot-reload]
                    [tolitius/boot-check]
-                   [boot-codox]]))))
+                   [boot-codox]
+                   [onetom/boot-lein-generate]]))))
 
 (require
   '[adzerk.boot-test :refer [test]]
   '[adzerk.boot-reload :refer [reload]]
   '[tolitius.boot-check :refer [with-yagni with-eastwood with-kibit with-bikeshed]]
-  '[codox.boot :refer [codox]])
+  '[codox.boot :refer [codox]]
+  '[boot.lein :refer [generate]])
 
 (set-env!
   :source-paths #{"test"}

--- a/jar-connector/pom.xml
+++ b/jar-connector/pom.xml
@@ -142,6 +142,7 @@
 							</value>
 						</property>
 					</systemPropertyVariables>
+					<useSystemClassLoader>false</useSystemClassLoader>
 					<excludes>
 						<exclude>${slipstream.test.excludes}</exclude>
 					</excludes>

--- a/jar-connector/pom.xml
+++ b/jar-connector/pom.xml
@@ -52,8 +52,16 @@
 
 		<dependency>
 			<groupId>com.sixsq.slipstream</groupId>
-                        <artifactId>SlipStreamUI-dep</artifactId>
-                        <type>pom</type>
+			<artifactId>SlipStreamCljResourcesTestServer-jar</artifactId>
+			<scope>test</scope>
+			<classifier>tests</classifier>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.sixsq.slipstream</groupId>
+			<artifactId>SlipStreamUI-dep</artifactId>
+			<type>pom</type>
 		</dependency>
 
 		<dependency>

--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/UsageRecorder.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/UsageRecorder.java
@@ -47,6 +47,11 @@ public class UsageRecorder {
 		logger.severe("You should NOT see this message in production: usage will *not* be recorded");
 	}
 
+	public static void unmuteForTests() {
+		isMuted = false;
+	}
+
+
 	public static void insertStart(String instanceId, String user, String cloud, List<UsageMetric> metrics) {
 		try {
 

--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/local/LocalConnector.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/local/LocalConnector.java
@@ -61,7 +61,8 @@ public class LocalConnector extends ConnectorBase {
 		vms = new ArrayList<Vm>();
 		for (int i = 0; i < MAX_VMS; i++) {
 			String randomState = randomState();
-			Vm vm = new Vm("instance_" + i, cloud, randomState, username, new LocalConnector().isVmUsable(randomState));
+			Vm vm = new Vm(UUID.randomUUID().toString(), cloud, randomState,
+					username, new LocalConnector().isVmUsable(randomState));
 			vms.add(vm);
 		}
 		Collector.update(vms, username, cloud);

--- a/jar-connector/src/test/java/com/sixsq/slipstream/accounting/AccountingRecordTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/accounting/AccountingRecordTest.java
@@ -15,6 +15,7 @@ import com.sixsq.slipstream.util.CommonTestUtil;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.*;
@@ -43,6 +44,8 @@ import static org.junit.Assert.fail;
  * -=================================================================-
  */
 
+// Ignored.  What is the point of running the same tests twice?
+@Ignore
 public class AccountingRecordTest extends RunFactoryTest {
 
 

--- a/jar-connector/src/test/java/com/sixsq/slipstream/connector/CollectorTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/connector/CollectorTest.java
@@ -55,6 +55,7 @@ public class CollectorTest extends RunTestBase {
 	public static void teardownClass() {
 	    ConnectorTestBase.teardownBackend();
 		SscljProxy.unmuteForTests();
+		UsageRecorder.unmuteForTests();
 	}
 
 	protected static void createUser() throws ConfigurationException, ValidationException {
@@ -70,6 +71,6 @@ public class CollectorTest extends RunTestBase {
 	public void collect() {
 		localConnector.generateDummyVms();
 		int res = Collector.collect(user, localConnector, 0);
-		assertThat(res,  is(LocalConnector.MAX_VMS));
+		assertThat(res, is(LocalConnector.MAX_VMS));
 	}
 }

--- a/jar-connector/src/test/java/com/sixsq/slipstream/connector/CollectorTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/connector/CollectorTest.java
@@ -23,7 +23,6 @@ package com.sixsq.slipstream.connector;
 
 import com.sixsq.slipstream.connector.local.LocalConnector;
 import com.sixsq.slipstream.connector.local.LocalUserParametersFactory;
-import com.sixsq.slipstream.es.CljElasticsearchHelper;
 import com.sixsq.slipstream.exceptions.ConfigurationException;
 import com.sixsq.slipstream.exceptions.SlipStreamException;
 import com.sixsq.slipstream.exceptions.ValidationException;
@@ -31,6 +30,7 @@ import com.sixsq.slipstream.persistence.Run;
 import com.sixsq.slipstream.persistence.UserParameter;
 import com.sixsq.slipstream.run.RunTestBase;
 import com.sixsq.slipstream.util.SscljProxy;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -42,13 +42,19 @@ public class CollectorTest extends RunTestBase {
 
 	@BeforeClass
 	public static void setupClass() throws ConfigurationException, SlipStreamException {
-		CljElasticsearchHelper.createAndInitTestDb();
+	    ConnectorTestBase.setupBackend();
 		UsageRecorder.muteForTests();
 		SscljProxy.muteForTests();
 		createUser();
 		for(Run r : Run.listAll()) {
 			r.remove();
 		}
+	}
+
+	@AfterClass
+	public static void teardownClass() {
+	    ConnectorTestBase.teardownBackend();
+		SscljProxy.unmuteForTests();
 	}
 
 	protected static void createUser() throws ConfigurationException, ValidationException {

--- a/jar-connector/src/test/java/com/sixsq/slipstream/connector/ConnectorTestBase.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/connector/ConnectorTestBase.java
@@ -21,16 +21,28 @@ package com.sixsq.slipstream.connector;
  */
 
 import com.sixsq.slipstream.es.CljElasticsearchHelper;
+import com.sixsq.slipstream.ssclj.app.SscljTestServer;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 public class ConnectorTestBase {
 
     @BeforeClass
     public static void setupClass() {
-        setupElasticseach();
+        setupBackend();
     }
 
-    public static void setupElasticseach() {
-        CljElasticsearchHelper.createAndInitTestDb();
+    public static void setupBackend() {
+        SscljTestServer.start();
+        CljElasticsearchHelper.initTestDb();
+    }
+
+    @AfterClass
+    public static void teardownClass() {
+        teardownBackend();
+    }
+
+    public static void teardownBackend() {
+        SscljTestServer.stop();
     }
 }

--- a/jar-connector/src/test/java/com/sixsq/slipstream/connector/UsageRecorderTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/connector/UsageRecorderTest.java
@@ -4,11 +4,9 @@ import com.sixsq.slipstream.persistence.Vm;
 import org.junit.Ignore;
 import org.junit.Test;
 
-public class UsageRecorderTest {
+public class UsageRecorderTest extends ConnectorTestBase {
 
-    // functional test, ignored in purpose, as there is a dependency to external service.
     @Test
-    @Ignore
     public void insertStart(){
         Vm vm = new Vm("instance-id", "cloud", "running", "user", true);
         for (int i=0; i<100; i++) {

--- a/jar-connector/src/test/java/com/sixsq/slipstream/connector/VirtualMachineHandlerTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/connector/VirtualMachineHandlerTest.java
@@ -4,7 +4,7 @@ import com.sixsq.slipstream.acl.TypePrincipal;
 import com.sixsq.slipstream.acl.TypePrincipalRight;
 import com.sixsq.slipstream.persistence.VirtualMachine;
 import com.sixsq.slipstream.persistence.Vm;
-import com.sixsq.slipstream.util.SscljProxy;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -12,77 +12,99 @@ import org.junit.Test;
 import java.util.List;
 import java.util.UUID;
 
+import com.sixsq.slipstream.ssclj.app.SscljTestServer;
+
 public class VirtualMachineHandlerTest {
     @BeforeClass
     public static void setupClass() {
-        SscljProxy.muteForTests();
+        SscljTestServer.start();
+    }
+
+    @AfterClass
+    public static void teardownClass() {
+        SscljTestServer.stop();
     }
 
     @Test
     public void addVMTest() {
         String instanceID = UUID.randomUUID().toString();
-        Vm vm = new Vm(instanceID, "0123-4567-8912", "Running", "user", true);
+        Vm vm = new Vm(instanceID, "cloud", "Running", "user", true);
 
         VirtualMachineHandler.handleVM(vm);
+
+        VirtualMachine vmResource = VirtualMachineHandler.fetchVirtualMachine("cloud", instanceID);
+        Assert.assertNotEquals(null, vmResource);
+        Assert.assertEquals(instanceID, vmResource.getInstanceID());
     }
 
     @Test
     public void removeVMTest() {
         String instanceID = UUID.randomUUID().toString();
-        Vm vm = new Vm(instanceID, "0123-4567-8912", "state", "Running", true);
+        Vm vm = new Vm(instanceID, "cloud", "Running", "user", true);
 
         VirtualMachineHandler.handleVM(vm);
+
+        VirtualMachine vmResource = VirtualMachineHandler.fetchVirtualMachine("cloud", instanceID);
+        Assert.assertNotNull(vmResource);
+        Assert.assertEquals(instanceID, vmResource.getInstanceID());
+
         VirtualMachineHandler.removeVM(vm);
+        SscljTestServer.refresh();
+        vmResource = VirtualMachineHandler.fetchVirtualMachine("cloud", instanceID);
+        Assert.assertNull(vmResource);
     }
 
     @Test
-    public void updateVMTestChangeState() {
+    public void updateVMChangeStateTest() {
         String instanceID = UUID.randomUUID().toString();
         String cloud = "aCloudName";
         Vm vm = new Vm(instanceID, cloud, "Running", "user", true);
         VirtualMachineHandler.handleVM(vm);
+        SscljTestServer.refresh();
 
         String newState = "Stopped";
         vm.setState(newState);
 
         VirtualMachineHandler.handleVM(vm);
+        SscljTestServer.refresh();
 
         VirtualMachine virtualMachine = VirtualMachineHandler.fetchVirtualMachine(cloud, instanceID);
-        if (virtualMachine != null) {
-            Assert.assertEquals(newState, virtualMachine.getState());
-        }
+        Assert.assertNotNull(virtualMachine);
+        Assert.assertEquals(newState, virtualMachine.getState());
     }
 
     @Test
-    public void updateVMTestWithRunResource() {
+    public void updateVMWithRunResourceTest() {
         String instanceID = UUID.randomUUID().toString();
         String cloud = "aCloudName";
+
         Vm vm = new Vm(instanceID, cloud, "Running", "user", true);
         VirtualMachineHandler.handleVM(vm);
+        SscljTestServer.refresh();
 
         vm.setRunUuid(UUID.randomUUID().toString());
         String runOwner = "runOwnerName";
+        String runOwnerHref = "user/" + runOwner;
         vm.setRunOwner(runOwner);
-
         VirtualMachineHandler.handleVM(vm);
+        SscljTestServer.refresh();
 
         VirtualMachine virtualMachine = VirtualMachineHandler.fetchVirtualMachine(cloud, instanceID);
-        if (virtualMachine != null) {
-            Assert.assertEquals(runOwner, virtualMachine.getDeployment().user);
-            List<TypePrincipalRight> rules = virtualMachine.getAcl().getRules();
-            Assert.assertNotNull(rules);
+        Assert.assertNotNull(virtualMachine);
+        Assert.assertEquals(runOwnerHref, virtualMachine.getDeployment().user.href);
+        List<TypePrincipalRight> rules = virtualMachine.getAcl().getRules();
+        Assert.assertNotNull(rules);
+        TypePrincipalRight right = getUserRuleFromACLRules(runOwner, rules);
+        Assert.assertNotEquals(null, right);
+        Assert.assertEquals(TypePrincipalRight.Right.VIEW, right.getRight());
+    }
 
-            boolean runOwnerFoundInAcl = false;
-            for (TypePrincipalRight r : rules) {
-                if ((r.getPrincipal() == runOwner) && (r.getType() == TypePrincipal.PrincipalType.USER)) {
-                    runOwnerFoundInAcl = true;
-                    Assert.assertEquals(TypePrincipalRight.Right.VIEW, r.getRight());
-                }
+    private static TypePrincipalRight getUserRuleFromACLRules(String userName, List<TypePrincipalRight> rules) {
+        for (TypePrincipalRight r : rules) {
+            if (r.getPrincipal().equals(userName) && r.getType().equals(TypePrincipal.PrincipalType.USER)) {
+                return r;
             }
-
-            Assert.assertTrue(runOwnerFoundInAcl);
-
-            Assert.assertEquals(runOwner, virtualMachine.getAcl().getRules());
         }
+        return null;
     }
 }

--- a/jar-connector/src/test/java/com/sixsq/slipstream/metering/MeteringTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/metering/MeteringTest.java
@@ -44,8 +44,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import com.sixsq.slipstream.ssclj.app.SscljTestServer;
-
 public class MeteringTest extends RunTestBase {
 
 	private static String CLOUD_A = "local";
@@ -57,8 +55,7 @@ public class MeteringTest extends RunTestBase {
 	@BeforeClass
 	public static void setupClass() throws ConfigurationException, SlipStreamException {
 		UsageRecorder.muteForTests();
-		SscljTestServer.start();
-		ConnectorTestBase.setupElasticseach();
+		ConnectorTestBase.setupBackend();
 		createUser();
 		String username = user.getName();
 
@@ -84,7 +81,7 @@ public class MeteringTest extends RunTestBase {
 
 	@AfterClass
 	public static void teardownClass() {
-		SscljTestServer.stop();
+	    ConnectorTestBase.teardownBackend();
 	}
 
 	private static Vm createVm(String instanceid, String cloud, String state, String user, String runId) {

--- a/jar-connector/src/test/java/com/sixsq/slipstream/metering/MeteringTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/metering/MeteringTest.java
@@ -30,8 +30,11 @@ import com.sixsq.slipstream.exceptions.SlipStreamException;
 import com.sixsq.slipstream.persistence.Vm;
 import com.sixsq.slipstream.run.RunTestBase;
 import com.sixsq.slipstream.util.CommonTestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.UUID;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +44,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.sixsq.slipstream.ssclj.app.SscljTestServer;
 
 public class MeteringTest extends RunTestBase {
 
@@ -53,6 +57,7 @@ public class MeteringTest extends RunTestBase {
 	@BeforeClass
 	public static void setupClass() throws ConfigurationException, SlipStreamException {
 		UsageRecorder.muteForTests();
+		SscljTestServer.start();
 		ConnectorTestBase.setupElasticseach();
 		createUser();
 		String username = user.getName();
@@ -65,17 +70,21 @@ public class MeteringTest extends RunTestBase {
 
 		List<Vm> vms = new ArrayList<Vm>();
 
-		vms.add(createVm("id_1", CLOUD_A, RUNNING_VM_STATE, username, runId));
-		vms.add(createVm("id_2", CLOUD_A, RUNNING_VM_STATE, username, runId));
-		vms.add(createVm("id_3", CLOUD_A, "Terminated", username, runId));
+		vms.add(createVm(UUID.randomUUID().toString(), CLOUD_A, RUNNING_VM_STATE, username, runId));
+		vms.add(createVm(UUID.randomUUID().toString(), CLOUD_A, RUNNING_VM_STATE, username, runId));
+		vms.add(createVm(UUID.randomUUID().toString(), CLOUD_A, "Terminated", username, runId));
 		Collector.update(vms, username, CLOUD_A);
 
 		vms.clear();
-		vms.add(createVm("id_1", CLOUD_B, "Pending", username, runId));
-		vms.add(createVm("id_2", CLOUD_B, RUNNING_VM_STATE, username, runId));
-		vms.add(createVm("id_3", CLOUD_B, "Terminated", username, runId));
+		vms.add(createVm(UUID.randomUUID().toString(), CLOUD_B, "Pending", username, runId));
+		vms.add(createVm(UUID.randomUUID().toString(), CLOUD_B, RUNNING_VM_STATE, username, runId));
+		vms.add(createVm(UUID.randomUUID().toString(), CLOUD_B, "Terminated", username, runId));
 		Collector.update(vms, username, CLOUD_B);
+	}
 
+	@AfterClass
+	public static void teardownClass() {
+		SscljTestServer.stop();
 	}
 
 	private static Vm createVm(String instanceid, String cloud, String state, String user, String runId) {

--- a/jar-connector/src/test/java/com/sixsq/slipstream/persistence/CollectorTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/persistence/CollectorTest.java
@@ -67,6 +67,7 @@ public class CollectorTest {
 		Collector.update(new ArrayList<Vm>(), username, firstCloud);
 		Collector.update(new ArrayList<Vm>(), username, secondCloud);
 		SscljProxy.unmuteForTests();
+		UsageRecorder.unmuteForTests();
 	}
 
 	@Test

--- a/jar-connector/src/test/java/com/sixsq/slipstream/persistence/CollectorTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/persistence/CollectorTest.java
@@ -66,6 +66,7 @@ public class CollectorTest {
 	public void tearDown() {
 		Collector.update(new ArrayList<Vm>(), username, firstCloud);
 		Collector.update(new ArrayList<Vm>(), username, secondCloud);
+		SscljProxy.unmuteForTests();
 	}
 
 	@Test

--- a/jar-connector/src/test/java/com/sixsq/slipstream/persistence/VmRuntimeParameterMappingTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/persistence/VmRuntimeParameterMappingTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 import com.sixsq.slipstream.util.SscljProxy;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,17 +55,14 @@ public class VmRuntimeParameterMappingTest {
 
 	@BeforeClass
 	public static void setupClass() throws ValidationException {
+		SscljProxy.muteForTests();
 		user = new User("user");
 		load();
 	}
 
-	@Before
-	public void setup() {
-		SscljProxy.muteForTests();
-	}
-
-	@After
-	public void tearDown() {
+	@AfterClass
+	public static void teardownClass() {
+	    SscljProxy.unmuteForTests();
 	}
 
 	@Test

--- a/jar-connector/src/test/java/com/sixsq/slipstream/run/RunFactoryTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/run/RunFactoryTest.java
@@ -28,7 +28,6 @@ import com.sixsq.slipstream.factory.RunFactory;
 import com.sixsq.slipstream.persistence.*;
 import com.sixsq.slipstream.util.CommonTestUtil;
 
-import com.sixsq.slipstream.util.ServiceOffersUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/jar-connector/src/test/java/com/sixsq/slipstream/run/RunTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/run/RunTest.java
@@ -68,6 +68,7 @@ public class RunTest extends RunTestBase {
 	public static void teardownClass() {
 		tearDownImages();
 		ConnectorTestBase.teardownBackend();
+		UsageRecorder.unmuteForTests();
 	}
 
 	@Test

--- a/jar-connector/src/test/java/com/sixsq/slipstream/run/RunTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/run/RunTest.java
@@ -58,7 +58,7 @@ public class RunTest extends RunTestBase {
 			ClassNotFoundException {
 		UsageRecorder.muteForTests();
 		Event.muteForTests();
-		ConnectorTestBase.setupElasticseach();
+		ConnectorTestBase.setupBackend();
 		setupImages();
 		CommonTestUtil
 				.resetAndLoadConnector(com.sixsq.slipstream.connector.local.LocalConnector.class);
@@ -67,6 +67,7 @@ public class RunTest extends RunTestBase {
 	@AfterClass
 	public static void teardownClass() {
 		tearDownImages();
+		ConnectorTestBase.teardownBackend();
 	}
 
 	@Test

--- a/jar-connector/src/test/java/com/sixsq/slipstream/run/RunTestBase.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/run/RunTestBase.java
@@ -20,7 +20,6 @@ import com.sixsq.slipstream.persistence.Node;
 import com.sixsq.slipstream.persistence.ParameterCategory;
 import com.sixsq.slipstream.persistence.Run;
 import com.sixsq.slipstream.persistence.RunType;
-import com.sixsq.slipstream.persistence.RuntimeParameter;
 import com.sixsq.slipstream.persistence.User;
 import com.sixsq.slipstream.persistence.UserParameter;
 import com.sixsq.slipstream.statemachine.States;

--- a/jar-connector/src/test/java/com/sixsq/slipstream/run/RuntimeParameterTest.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/run/RuntimeParameterTest.java
@@ -29,13 +29,13 @@ import static org.junit.Assert.fail;
 
 import java.lang.reflect.InvocationTargetException;
 
+import com.sixsq.slipstream.connector.ConnectorTestBase;
 import com.sixsq.slipstream.event.Event;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-import com.sixsq.slipstream.es.CljElasticsearchHelper;
 import com.sixsq.slipstream.exceptions.SlipStreamException;
 import com.sixsq.slipstream.exceptions.ValidationException;
 import com.sixsq.slipstream.factory.RunFactory;
@@ -57,7 +57,7 @@ public class RuntimeParameterTest {
 			InvocationTargetException, NoSuchMethodException, ClassNotFoundException {
 
 		Event.muteForTests();
-                CljElasticsearchHelper.createAndInitTestDb();
+		ConnectorTestBase.setupBackend();
 
 		user = CommonTestUtil.createTestUser();
 
@@ -69,6 +69,7 @@ public class RuntimeParameterTest {
 	@AfterClass
 	public static void teardownClass() {
 		CommonTestUtil.deleteUser(user);
+		ConnectorTestBase.teardownBackend();
 	}
 
 	@Test(expected = ValidationException.class)

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/es/CljElasticsearchHelper.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/es/CljElasticsearchHelper.java
@@ -43,7 +43,7 @@ public class CljElasticsearchHelper {
      * Connection to a external Elasticsearch defined by ES_HOST and ES_PORT env vars.
      */
     public static void init() {
-        logger.info("Creating DB client and setting DB CRUD implementation.");
+        logger.info("Creating DB client and setting ES DB CRUD implementation.");
         requireNs(NS_SERIALIZERS_UTILS);
         Clojure.var(NS_SERIALIZERS_UTILS, "db-client-and-crud-impl").invoke();
         initializeConnectorTemplates();
@@ -58,22 +58,22 @@ public class CljElasticsearchHelper {
      * - resource templates (including connector templates).
      */
     public static void createAndInitTestDb() {
-        logger.info("Creating test DB node/client and setting DB CRUD implementation.");
+        logger.info("Creating test DB node/client and setting ES DB CRUD implementation.");
         requireNs(NS_SERIALIZERS_UTILS);
         Clojure.var(NS_SERIALIZERS_UTILS, "test-db-client-and-crud-impl").invoke();
+        initTestDb();
+    }
+
+    public static void initTestDb() {
         addDefaultServiceConfigToDb();
         initializeConnectorTemplates();
         pushServerConfig();
     }
 
-    public static void classpath () {
-        logger.info("-->>> Printing classpath.");
-        ClassLoader cl = ClassLoader.getSystemClassLoader();
-        URL[] urls = ((URLClassLoader)cl).getURLs();
-        logger.info("-->>> # of urls " + urls.length);
-        for(URL url: urls){
-            System.out.println(url.getFile());
-        }
+    public static void stopAndUnbindTestDb() {
+        logger.info("Stop and unbind test ES DB.");
+        requireNs(NS_SERIALIZERS_UTILS);
+        Clojure.var(NS_SERIALIZERS_UTILS, "test-db-unset-client-and-impl").invoke();
     }
 
     public static void initializeConnectorTemplates() {
@@ -88,7 +88,7 @@ public class CljElasticsearchHelper {
     }
 
     private static void addDefaultServiceConfigToDb() {
-        logger.info("Adding default service configuration to DB.");
+        logger.info("Adding default service configuration to ES DB.");
         setDbCrudImpl();
         requireNs(NS_SERIALIZERS_SERVICE_CONFIG_IMPL);
 		Clojure.var(NS_SERIALIZERS_SERVICE_CONFIG_IMPL, "db-add-default-config").invoke();

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/util/SscljProxy.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/util/SscljProxy.java
@@ -328,4 +328,8 @@ public class SscljProxy {
         logger.severe("You should NOT see this message in production: request to SSCLJ won't be made");
     }
 
+    public static void unmuteForTests() {
+        isMuted = false;
+    }
+
 }

--- a/jar-persistence/src/test/java/com/sixsq/slipstream/util/ServiceOffersUtilTest.java
+++ b/jar-persistence/src/test/java/com/sixsq/slipstream/util/ServiceOffersUtilTest.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.sixsq.slipstream.event.Event;
 import com.sixsq.slipstream.exceptions.ValidationException;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -18,6 +19,11 @@ public class ServiceOffersUtilTest {
     @BeforeClass
     public static void setupClass() {
         SscljProxy.muteForTests();
+    }
+
+    @AfterClass
+    public static void teardownClass() {
+        SscljProxy.unmuteForTests();
     }
 
     @Test
@@ -55,7 +61,6 @@ public class ServiceOffersUtilTest {
 
     @Test
     public void serviceOfferAttributeName() {
-        JsonObject nullserviceOffer = null;
         JsonObject emptyServiceOffer = new JsonObject();
         String anAttributeName = "myAttribute";
         String valueName = "myValue";

--- a/jar-service/pom.xml
+++ b/jar-service/pom.xml
@@ -95,6 +95,14 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>com.sixsq.slipstream</groupId>
+			<artifactId>SlipStreamCljResourcesTestServer-jar</artifactId>
+			<scope>test</scope>
+			<classifier>tests</classifier>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- required for passing tests on clean build -->
 		<dependency>
 			<groupId>com.sixsq.slipstream</groupId>
@@ -276,6 +284,7 @@
 					<systemPropertyVariables>
 						<slipstream.config.dir>${project.build.directory}/configuration</slipstream.config.dir>
 					</systemPropertyVariables>
+					<useSystemClassLoader>false</useSystemClassLoader>
 					<includes>
 						<include>${slipstream.test.includes}</include>
 					</includes>

--- a/jar-service/src/test/java/com/sixsq/slipstream/configuration/ServiceConfigurationTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/configuration/ServiceConfigurationTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.BeforeClass;
 
@@ -38,8 +39,13 @@ import com.sixsq.slipstream.es.CljElasticsearchHelper;
 public class ServiceConfigurationTest {
 
 	@BeforeClass
-	public static void createTestElasticsearchDb(){
+	public static void setupClass(){
 		CljElasticsearchHelper.createAndInitTestDb();
+	}
+
+	@AfterClass
+	public static void teardownClass(){
+		CljElasticsearchHelper.stopAndUnbindTestDb();
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/jar-service/src/test/java/com/sixsq/slipstream/connector/ConnectorTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/connector/ConnectorTest.java
@@ -29,6 +29,7 @@ import com.sixsq.slipstream.exceptions.ValidationException;
 import com.sixsq.slipstream.factory.RunFactory;
 import com.sixsq.slipstream.persistence.*;
 import com.sixsq.slipstream.util.CommonTestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -50,6 +51,11 @@ public class ConnectorTest extends ConnectorDummy {
 	public static void setupClass() {
 		Event.muteForTests();
 		CljElasticsearchHelper.createAndInitTestDb();
+	}
+
+	@AfterClass
+	public static void teardownClass() {
+		CljElasticsearchHelper.stopAndUnbindTestDb();
 	}
 
 	@Test

--- a/jar-service/src/test/java/com/sixsq/slipstream/run/QuotaTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/run/QuotaTest.java
@@ -27,7 +27,9 @@ import com.sixsq.slipstream.exceptions.ConfigurationException;
 import com.sixsq.slipstream.exceptions.QuotaException;
 import com.sixsq.slipstream.exceptions.ValidationException;
 import com.sixsq.slipstream.persistence.*;
+import com.sixsq.slipstream.ssclj.app.SscljTestServer;
 import com.sixsq.slipstream.util.SscljProxy;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -43,11 +45,26 @@ import com.sixsq.slipstream.persistence.ServiceConfiguration;
 
 public class QuotaTest {
 
+	public static void setupBackend() {
+		SscljTestServer.start();
+		CljElasticsearchHelper.initTestDb();
+	}
+
+	public static void teardownBackend() {
+		SscljTestServer.stop();
+	}
+
 	@BeforeClass
 	public static void setupClass() {
 		Event.muteForTests();
 		SscljProxy.muteForTests();
-		CljElasticsearchHelper.createAndInitTestDb();
+		setupBackend();
+	}
+
+	@AfterClass
+	public static void teardownClass() {
+	    teardownBackend();
+		SscljProxy.unmuteForTests();
 	}
 
 	private Run testQuotaCreateRun(User user, String cloud)

--- a/jar-service/src/test/java/com/sixsq/slipstream/run/RunListResourceTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/run/RunListResourceTest.java
@@ -110,11 +110,9 @@ public class RunListResourceTest extends ResourceTestBase {
 	}
 
 	@AfterClass
-	public static void teardownClass() throws ConfigurationException,
-			ValidationException {
-
+	public static void teardownClass() throws ConfigurationException, ValidationException {
 		removeAllRuns();
-
+		SscljProxy.unmuteForTests();
 	}
 
 	@Before

--- a/jar-service/src/test/java/com/sixsq/slipstream/run/RuntimeParameterStateMachineTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/run/RuntimeParameterStateMachineTest.java
@@ -59,6 +59,7 @@ public class RuntimeParameterStateMachineTest extends
 	@After
 	public void tearDown() {
 		removeDeployments();
+		SscljProxy.unmuteForTests();
 	}
 
 	@Test

--- a/jar-service/src/test/java/com/sixsq/slipstream/statemachine/StateMachinetTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/statemachine/StateMachinetTest.java
@@ -91,6 +91,7 @@ public class StateMachinetTest {
 		removeRuns();
 		List<Run> runs = Run.listAll();
 		assertEquals(0, runs.size());
+		CljElasticsearchHelper.stopAndUnbindTestDb();
 	}
 
 	private static void removeRuns() throws ValidationException {

--- a/jar-service/src/test/java/com/sixsq/slipstream/util/ResourceTestBase.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/util/ResourceTestBase.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.sixsq.slipstream.es.CljElasticsearchHelper;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.restlet.Request;
 import org.restlet.Response;
@@ -61,6 +62,11 @@ public class ResourceTestBase extends RunTestBase {
 	@BeforeClass
 	public static void createTestElasticsearchDb(){
 		CljElasticsearchHelper.createAndInitTestDb();
+	}
+
+	@AfterClass
+	public static void stopTestElasticsearchDb(){
+		CljElasticsearchHelper.stopAndUnbindTestDb();
 	}
 
 	protected static final String TEST_REQUEST_NAME = "/test/request";

--- a/ssclj/jar/build.boot
+++ b/ssclj/jar/build.boot
@@ -123,6 +123,8 @@
            (sift :include #{#".*_test\.clj"
                             #".*test_utils\.clj"
                             #"test_helper\.clj"
+                            #"test_server.clj"
+                            #"SscljTestServer.clj"
                             #".*seeds.*"
                             #".*example\.clj"}
                  :invert true)
@@ -152,6 +154,8 @@
            (sift :include #{#".*_test\.clj"
                             #".*test_utils\.clj"
                             #"test_helper\.clj"
+                            #"test_server.clj"
+                            #"SscljTestServer.clj"
                             #".*seeds.*"
                             #".*example\.clj"
                             #".*Test\.java"

--- a/ssclj/jar/pom.xml
+++ b/ssclj/jar/pom.xml
@@ -48,6 +48,13 @@
       <type>pom</type>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.sixsq.slipstream</groupId>
+      <artifactId>utils-dep</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/app/server.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/app/server.clj
@@ -76,9 +76,7 @@
    (zku/set-client! (zku/create-client))
 
    (set-persistence-impl)
-   (log/info "resources/initialize")
    (resources/initialize)
-   (log/info "resources/initialize --- initialized")
    (let [handler (create-ring-handler)]
      (graphite/start-graphite-reporter)
      (aleph/start-container handler port))))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/app/server.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/app/server.clj
@@ -76,7 +76,9 @@
    (zku/set-client! (zku/create-client))
 
    (set-persistence-impl)
+   (log/info "resources/initialize")
    (resources/initialize)
+   (log/info "resources/initialize --- initialized")
    (let [handler (create-ring-handler)]
      (graphite/start-graphite-reporter)
      (aleph/start-container handler port))))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/common/dynamic_load.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/common/dynamic_load.clj
@@ -64,4 +64,6 @@
   "Runs the initialize function for all resources that define it."
   []
   (doall
-    (map initialize-resource (resource-namespaces))))
+    (let [rn (resource-namespaces)
+          _ (log/info "resource-namespaces" rn)]
+      (map initialize-resource rn))))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/common/dynamic_load.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/common/dynamic_load.clj
@@ -64,6 +64,4 @@
   "Runs the initialize function for all resources that define it."
   []
   (doall
-    (let [rn (resource-namespaces)
-          _ (log/info "resource-namespaces" rn)]
-      (map initialize-resource rn))))
+    (map initialize-resource (resource-namespaces))))


### PR DESCRIPTION
- using ssclj+es+zk via SscljTestServer.start/stop
- updated creation and usage of the separate ES fixture in CljElasticsearchHelper
- explicit "unmute" because "mute" uses class's static field and silences all successive calls
- enabled/updated UsageRecorderTest and VirtualMachineHandlerTest

Connected to #1252 