### PR TITLE
renamed credential-cloud-lifecycle-test to get it in the tests jar

### DIFF
--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/credential_cloud_lifecycle_test_utils.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/credential_cloud_lifecycle_test_utils.clj
@@ -1,5 +1,5 @@
-(ns com.sixsq.slipstream.ssclj.resources.credential-cloud-lifecycle-test
-  (:require
+(ns com.sixsq.slipstream.ssclj.resources.credential-cloud-lifecycle-test-utils
+    (:require
     [clojure.test :refer [deftest is are use-fixtures]]
     [peridot.core :refer :all]
     [clojure.data.json :as json]


### PR DESCRIPTION
Connected to https://github.com/SixSq/SlipStreamConnectors/pull/113