### PR TITLE
change user/* route in cimi to allow for OIDC user names

### DIFF
--- a/dummy-connector/java/jar/src/main/java/com/sixsq/slipstream/connector/dummy/DummyCloudCredDef.java
+++ b/dummy-connector/java/jar/src/main/java/com/sixsq/slipstream/connector/dummy/DummyCloudCredDef.java
@@ -10,14 +10,12 @@ import java.util.Map;
 
 public class DummyCloudCredDef extends CloudCredential<DummyCloudCredDef> {
 
-    public String href = "credential-template/store-cloud-cred-dummy";
-
     @SerializedName("domain-name")
     public String domainName;
 
     public DummyCloudCredDef(String instanceName, String key, String secret,
                              String domainName) {
-        super(instanceName, key, secret);
+        super(instanceName, key, secret, DummyConnector.CLOUD_SERVICE_NAME);
         this.domainName = domainName;
     }
 
@@ -28,7 +26,7 @@ public class DummyCloudCredDef extends CloudCredential<DummyCloudCredDef> {
     }
 
     DummyCloudCredDef(String instanceName, Map<String, UserParameter> params) {
-        super(instanceName);
+        super(instanceName, DummyConnector.CLOUD_SERVICE_NAME);
         setParams(params);
     }
 

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/ICloudCredential.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/ICloudCredential.java
@@ -7,6 +7,10 @@ import com.sixsq.slipstream.persistence.UserParameter;
 import java.util.Map;
 
 public interface ICloudCredential<T> {
+    public String href = null;
+
+    public void removeHref();
+
     String getConnectorInstanceName();
 
     String toJson();

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/UserGeneralParams.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/UserGeneralParams.java
@@ -22,7 +22,8 @@ public class UserGeneralParams {
     public String id;
     public String paramsType = "execution";
 
-    public UserGeneralParams() { }
+    public UserGeneralParams() {
+    }
 
     public UserGeneralParams(String defaultCloudService, String keepRunning,
                              String mailUsage, Integer timeout, Integer
@@ -41,8 +42,13 @@ public class UserGeneralParams {
 
     public void setParameter(UserParameter param) {
         String pName = param.getName();
-        String pValue = param.getValue();
         String category = param.getCategory();
+        String pValue;
+        if (null == param.getValue()) {
+            pValue = "";
+        } else {
+            pValue = param.getValue();
+        }
         if (pName.equals(UserParameter.constructKey(category,
                 UserParameter.KEY_KEEP_RUNNING))) {
             this.keepRunning = pValue;
@@ -51,21 +57,30 @@ public class UserGeneralParams {
             this.mailUsage = pValue;
         } else if (pName.equals(UserParameter.constructKey(category,
                 ExecutionControlUserParametersFactory.VERBOSITY_LEVEL))) {
-            this.verbosityLevel = Integer.parseInt(pValue);
+            if (pValue.isEmpty()) {
+                this.verbosityLevel = Integer.parseInt(ExecutionControlUserParametersFactory.VERBOSITY_LEVEL_DEFAULT);
+            } else {
+                this.verbosityLevel = Integer.parseInt(pValue);
+            }
         } else if (pName.equals(UserParameter.constructKey(category,
                 UserParameter.DEFAULT_CLOUD_SERVICE_PARAMETER_NAME))) {
             this.defaultCloudService = pValue;
         } else if (pName.equals(UserParameter.constructKey(category,
                 UserParameter.KEY_TIMEOUT))) {
-            this.timeout = Integer.parseInt(pValue);
+            if (pValue.isEmpty()) {
+                this.timeout = 0;
+            } else {
+                this.timeout = Integer.parseInt(pValue);
+            }
         } else if (pName.equals(UserParameter.constructKey(category,
                 UserParameter.SSHKEY_PARAMETER_NAME))) {
             this.sshPublicKey = pValue;
         }
     }
+
     public void setParameters(Collection<UserParameter> params) {
-        for (UserParameter p: params) {
-           setParameter(p);
+        for (UserParameter p : params) {
+            setParameter(p);
         }
     }
 

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/util/SscljProxy.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/util/SscljProxy.java
@@ -90,6 +90,10 @@ public class SscljProxy {
         return request(Method.PUT, resource, obj, username, null, null, null);
     }
 
+    public static Response put(String resource, String username, Object obj, boolean throwException) {
+        return request(Method.PUT, resource, obj, username, null, null, throwException);
+    }
+
     public static Response post(String resource, Object obj) {
         return request(Method.POST, resource, obj, null, null, null, null);
     }

--- a/ssclj/jar/src/com/sixsq/slipstream/auth/utils/db.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/auth/utils/db.clj
@@ -159,7 +159,7 @@
                     :authentications
                              {"unknown" {:roles #{"ANON"}, :identity "unknown"}}}
      :sixsq.slipstream.authn/claims
-                   {:username "unknown", :roles #{"ANON"}}
+                   {:username "unknown", :roles "ANON"}
      :params       {:resource-name "user"}
      :route-params {:resource-name "user"}
      :user-roles   #{"ANON"}

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/app/routes.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/app/routes.clj
@@ -62,9 +62,20 @@
     (GET uri-github request (gh/callback-github request (cf/property-value :main-server)))
     (GET uri-cyclone request (cy/callback-cyclone request (cf/property-value :main-server)))))
 
+(def user-routes
+  (let-routes [uri (str p/service-context ":resource-name{user}/:uuid{.*}")]
+    (GET uri request
+      (crud/retrieve request))
+    (PUT uri request
+      (crud/edit request))
+    (DELETE uri request
+      (crud/delete request))
+    (ANY uri request
+      (throw (r/ex-bad-method request)))))
+
 (def final-routes
-  [
-   collection-routes
+  [collection-routes
+   user-routes
    resource-routes
    action-routes
    auth-routes

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/user.cljc
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/user.cljc
@@ -1,5 +1,6 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.user
   (:require
+    [clojure.string :as str]
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.util.spec :as su]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
@@ -10,6 +11,8 @@
 (s/def :cimi.user/lastName :cimi.core/nonblank-string)
 (s/def :cimi.user/organization string?)
 
+(s/def :cimi.user/id (s/and string? #(re-matches #"^user/.*" %)))
+
 (def user-keys-spec
   {:req-un [:cimi.user/username
             :cimi.user/emailAddress]
@@ -17,6 +20,26 @@
             :cimi.user/lastName
             :cimi.user/organization]})
 
+; substitute :cimi.common/id with less strict cimi.user/id
+#_(def user-common-attrs
+    (->> c/common-attrs
+         :req-un
+         (remove #{:cimi.common/id})
+         (concat [:cimi.user/id])
+         (hash-map :req-un)
+         (merge c/common-attrs)))
+; FIXME: fix the above def and remove this copy/paste
+(def ^:const user-common-attrs
+  {:req-un [:cimi.user/id
+            :cimi.common/resourceURI
+            :cimi.common/created
+            :cimi.common/updated
+            :cimi.common/acl]
+   :opt-un [:cimi.common/name
+            :cimi.common/description
+            :cimi.common/properties
+            :cimi.common/operations]})
+
 (s/def :cimi/user
-  (su/only-keys-maps c/common-attrs
+  (su/only-keys-maps user-common-attrs
                      user-keys-spec))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/user_auto.cljc
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/user_auto.cljc
@@ -37,6 +37,6 @@
 
 (s/def :cimi/user-auto
   (su/only-keys-maps
-    c/common-attrs
+    ps/user-common-attrs
     ps/user-keys-spec
     user-auto-keys-spec))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/user_direct.cljc
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/user_direct.cljc
@@ -1,0 +1,41 @@
+(ns com.sixsq.slipstream.ssclj.resources.spec.user-direct
+  (:require
+    [clojure.spec.alpha :as s]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.user :as ps]
+    [clojure.spec.alpha :as s]))
+
+(s/def :cimi.user-direct/method :cimi.core/identifier)
+(s/def :cimi.user-direct/href string?)
+(s/def :cimi.user-direct/password :cimi.core/nonblank-string)
+(s/def :cimi.user-direct/roles string?)
+(s/def :cimi.user-direct/state :cimi.core/nonblank-string)
+(s/def :cimi.user-direct/creation :cimi.core/timestamp)
+(s/def :cimi.user-direct/lastOnline :cimi.core/timestamp)
+(s/def :cimi.user-direct/lastExecute :cimi.core/timestamp)
+(s/def :cimi.user-direct/activeSince :cimi.core/timestamp)
+(s/def :cimi.user-direct/isSuperUser boolean?)
+(s/def :cimi.user-direct/deleted boolean?)
+(s/def :cimi.user-direct/githublogin string?)
+(s/def :cimi.user-direct/cyclonelogin string?)
+
+(def user-direct-keys-spec
+  {:opt-un [:cimi.user-direct/method
+            :cimi.user-direct/href
+            :cimi.user-direct/password
+            :cimi.user-direct/roles
+            :cimi.user-direct/isSuperUser
+            :cimi.user-direct/state
+            :cimi.user-direct/deleted
+            :cimi.user-direct/creation
+            :cimi.user-direct/lastOnline
+            :cimi.user-direct/lastExecute
+            :cimi.user-direct/activeSince
+            :cimi.user-direct/githublogin
+            :cimi.user-direct/cyclonelogin]})
+
+(s/def :cimi/user-direct
+  (su/only-keys-maps
+    ps/user-common-attrs
+    ps/user-keys-spec
+    user-direct-keys-spec))

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/user_template.cljc
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/user_template.cljc
@@ -2,8 +2,8 @@
   (:require
     [clojure.spec.alpha :as s]
     [clojure.spec.gen.alpha :as gen]
-    [clojure.string :as str]
     [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.user :as us]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
 
 ;; All user templates must indicate the method used to create the user.

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/user_template_direct.cljc
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/spec/user_template_direct.cljc
@@ -3,7 +3,6 @@
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.util.spec :as su]
     [com.sixsq.slipstream.ssclj.resources.spec.user :as u]
-    [com.sixsq.slipstream.ssclj.resources.spec.user-template]
     [com.sixsq.slipstream.ssclj.resources.spec.user-template :as ps]))
 
 (s/def :cimi.user-template.direct/href :cimi.user-template/href)
@@ -16,6 +15,8 @@
 (s/def :cimi.user-template.direct/activeSince :cimi.core/timestamp)
 (s/def :cimi.user-template.direct/isSuperUser boolean?)
 (s/def :cimi.user-template.direct/deleted boolean?)
+(s/def :cimi.user-template.direct/githublogin string?)
+(s/def :cimi.user-template.direct/cyclonelogin string?)
 
 (def user-tempate-direct-keys
   {:opt-un [:cimi.user-template.direct/href
@@ -27,7 +28,9 @@
             :cimi.user-template.direct/creation
             :cimi.user-template.direct/lastOnline
             :cimi.user-template.direct/lastExecute
-            :cimi.user-template.direct/activeSince]})
+            :cimi.user-template.direct/activeSince
+            :cimi.user-template.direct/githublogin
+            :cimi.user-template.direct/cyclonelogin]})
 
 (def user-template-keys-spec-req
   (su/merge-keys-specs

--- a/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/user_direct.clj
+++ b/ssclj/jar/src/com/sixsq/slipstream/ssclj/resources/user_direct.clj
@@ -2,6 +2,7 @@
   (:require
     [com.sixsq.slipstream.ssclj.resources.spec.user]
     [com.sixsq.slipstream.ssclj.resources.spec.user-template-direct]
+    [com.sixsq.slipstream.ssclj.resources.spec.user-direct]
     [com.sixsq.slipstream.ssclj.resources.user :as p]
     [com.sixsq.slipstream.ssclj.resources.user-template-direct :as tpl]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]))
@@ -9,7 +10,7 @@
 ;;
 ;; validate the create resource
 ;;
-(def validate-fn (u/create-spec-validation-fn :cimi/user-template.direct))
+(def validate-fn (u/create-spec-validation-fn :cimi/user-direct))
 (defmethod p/validate-subtype tpl/registration-method
   [resource]
   (validate-fn resource))

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/spec/user_test.cljc
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/spec/user_test.cljc
@@ -13,12 +13,13 @@
 
 (deftest check-user-schema
   (let [timestamp "1964-08-25T10:00:00.0Z"
-        cfg {:id           (str resource-url "/user-abc")
+        uname "120720737412@eduid.chhttps://eduid.ch/idp/shibboleth!https://fed-id.nuv.la/samlbridge/module.php/saml/sp/metadata.php/sixsq-saml-bridge!iqqrh4oiyshzcw9o40cvo0+pgka="
+        cfg {:id           (str resource-url "/" uname)
              :resourceURI  resource-uri
              :created      timestamp
              :updated      timestamp
              :acl          valid-acl
-             :username     "ssuser"
+             :username     uname
              :emailAddress "me@example.com"
              :firstName    "John"
              :lastName     "Smith"}]

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/user_auto_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/user_auto_lifecycle_test.clj
@@ -9,8 +9,6 @@
     [com.sixsq.slipstream.ssclj.resources.lifecycle-test-utils :as ltu]
     [com.sixsq.slipstream.ssclj.resources.common.dynamic-load :as dyn]
     [com.sixsq.slipstream.ssclj.middleware.authn-info-header :refer [authn-info-header]]
-    [com.sixsq.slipstream.auth.internal :as auth-internal]
-    [com.sixsq.slipstream.auth.utils.db :as db]
     [com.sixsq.slipstream.ssclj.app.params :as p]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [clojure.spec.alpha :as s]))
@@ -23,14 +21,15 @@
 (dyn/initialize)
 
 (deftest lifecycle
-  (let [href (str ct/resource-url "/" auto/registration-method)
+  (let [uname "120720737412@eduid.chhttps://eduid.ch/idp/shibboleth!https://fed-id.nuv.la/samlbridge/module.php/saml/sp/metadata.php/sixsq-saml-bridge!iqqrh4oiyshzcw9o40cvo0+pgka="
+        href (str ct/resource-url "/" auto/registration-method)
         template-url (str p/service-context ct/resource-url "/" auto/registration-method)
 
         session (-> (ltu/ring-app)
                     session
                     (content-type "application/json"))
         session-admin (header session authn-info-header "root ADMIN")
-        session-user (header session authn-info-header "jane USER ANON")
+        session-user (header session authn-info-header (format "%s USER ANON" uname))
         session-anon (header session authn-info-header "unknown ANON")
 
         name-attr "name"
@@ -44,13 +43,13 @@
                      (get-in [:response :body]))
 
         no-href-create {:userTemplate (ltu/strip-unwanted-attrs (assoc template
-                                                                  :username "user"
+                                                                  :username uname
                                                                   :emailAddress "user@example.org"))}
         href-create {:name         name-attr
                      :description  description-attr
                      :properties   properties-attr
                      :userTemplate {:href         href
-                                    :username     "jane"
+                                    :username     uname
                                     :emailAddress "jane@example.org"
                                     :firstName    "Jane"
                                     :lastName     "Tester"

--- a/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/user_direct_lifecycle_test.clj
+++ b/ssclj/jar/test/com/sixsq/slipstream/ssclj/resources/user_direct_lifecycle_test.clj
@@ -23,14 +23,15 @@
 (dyn/initialize)
 
 (deftest lifecycle
-  (let [href (str ct/resource-url "/" direct/registration-method)
+  (let [uname "120720737412@eduid.chhttps://eduid.ch/idp/shibboleth!https://fed-id.nuv.la/samlbridge/module.php/saml/sp/metadata.php/sixsq-saml-bridge!iqqrh4oiyshzcw9o40cvo0+pgka="
+        href (str ct/resource-url "/" direct/registration-method)
         template-url (str p/service-context ct/resource-url "/" direct/registration-method)
 
         session (-> (ltu/ring-app)
                     session
                     (content-type "application/json"))
         session-admin (header session authn-info-header "root ADMIN")
-        session-user (header session authn-info-header "jane USER ANON")
+        session-user (header session authn-info-header (format "%s USER ANON" uname))
         session-anon (header session authn-info-header "unknown ANON")
 
         template (-> session-admin
@@ -40,10 +41,10 @@
                      (get-in [:response :body]))
 
         no-href-create {:userTemplate (ltu/strip-unwanted-attrs (assoc template
-                                                                  :username "user"
+                                                                  :username uname
                                                                   :emailAddress "user@example.org"))}
         href-create {:userTemplate {:href         href
-                                    :username     "user"
+                                    :username     uname
                                     :emailAddress "user@example.org"}}
         invalid-create (assoc-in href-create [:userTemplate :href] "user-template/unknown-template")]
 
@@ -102,7 +103,7 @@
 
     ;; create a user via admin
     (let [create-req {:userTemplate {:href         href
-                                     :username     "jane"
+                                     :username     uname
                                      :emailAddress "jane@example.org"}}
           resp (-> session-admin
                    (request base-uri


### PR DESCRIPTION
- updates and fixes of user* specs;
- pushed 'href' up to parent CloudCredential class;
- fixed NPEs in UserGeneralParams setters/getters.

Connected to #1347 