### PR TITLE
switch to using static gson instances

### DIFF
--- a/jar-connector/src/test/java/com/sixsq/slipstream/util/CloudCredDefTestBase.java
+++ b/jar-connector/src/test/java/com/sixsq/slipstream/util/CloudCredDefTestBase.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.assertTrue;
 
 public class CloudCredDefTestBase {
 
+    private static final Gson gson = new Gson();
+
     @BeforeClass
     public static void setupClass() {
         SscljTestServer.start();
@@ -54,7 +56,7 @@ public class CloudCredDefTestBase {
 
         SscljTestServer.refresh();
 
-        HashMap<String, String> response = (new Gson()).fromJson(resp.getEntityAsText(), HashMap.class);
+        HashMap<String, String> response = gson.fromJson(resp.getEntityAsText(), HashMap.class);
         String resourceId = response.get("resource-id");
         resp = SscljProxy.get(SscljProxy.BASE_RESOURCE + resourceId, "test USER");
         assertFalse(resp.toString(), SscljProxy.isError(resp));

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/connector/CloudConnector.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/connector/CloudConnector.java
@@ -3,6 +3,7 @@ package com.sixsq.slipstream.connector;
 import com.google.gson.Gson;
 
 public class CloudConnector {
+    private static final Gson gson = new Gson();
     public String cloudServiceType;
     public String instanceName;
 
@@ -10,6 +11,6 @@ public class CloudConnector {
     }
 
     public static CloudConnector fromJson(String jsonRecords) {
-        return (new Gson()).fromJson(jsonRecords, CloudConnector.class);
+        return gson.fromJson(jsonRecords, CloudConnector.class);
     }
 }

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/CloudCredential.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/CloudCredential.java
@@ -21,6 +21,9 @@ import java.util.List;
 import java.util.Map;
 
 public class CloudCredential<T> implements ICloudCredential<T> {
+
+    private static final Gson gson = new Gson();
+
     public String id;
 
     public String href = null;
@@ -62,11 +65,11 @@ public class CloudCredential<T> implements ICloudCredential<T> {
     }
 
     public String toJson() {
-        return (new Gson()).toJson(this);
+        return gson.toJson(this);
     }
 
     public static Object fromJson(String json, Class klass) {
-        return (new Gson()).fromJson(json, klass);
+        return gson.fromJson(json, klass);
     }
 
     public boolean equalsTo(ICloudCredential<T> other) {

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/CloudCredentialCollection.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/CloudCredentialCollection.java
@@ -26,6 +26,8 @@ import java.util.List;
  */
 public class CloudCredentialCollection {
 
+    private static final Gson gson = new Gson();
+
     private List<CloudCredential> credentials = new ArrayList<>();
     private Integer count;
 
@@ -38,7 +40,6 @@ public class CloudCredentialCollection {
     }
 
     public static Object fromJson(String jsonRecords, Class klass) {
-        Gson gson = new Gson();
         return gson.fromJson(jsonRecords, klass);
     }
 }

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/CloudCredentialCreateTmpl.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/CloudCredentialCreateTmpl.java
@@ -3,6 +3,9 @@ package com.sixsq.slipstream.credentials;
 import com.google.gson.Gson;
 
 public class CloudCredentialCreateTmpl {
+
+    private static final Gson gson = new Gson();
+
     public ICloudCredential credentialTemplate;
 
     public CloudCredentialCreateTmpl(ICloudCredential cd) {
@@ -13,12 +16,10 @@ public class CloudCredentialCreateTmpl {
     }
 
     public String toJson() {
-        Gson gson = new Gson();
         return gson.toJson(this);
     }
 
     public static CloudCredentialCreateTmpl fromJson(String json) {
-        Gson gson = new Gson();
         return gson.fromJson(json, CloudCredentialCreateTmpl.class);
     }
 }

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/SshCredential.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/SshCredential.java
@@ -14,6 +14,9 @@ import java.util.List;
 import java.util.Map;
 
 public class SshCredential<T> implements ISshCredential<T> {
+
+    public static final Gson gson = new Gson();
+
     public String href = "credential-template/import-ssh-public-key";
 
     public String id;
@@ -34,11 +37,11 @@ public class SshCredential<T> implements ISshCredential<T> {
     }
 
     public String toJson() {
-        return (new Gson()).toJson(this);
+        return gson.toJson(this);
     }
 
     public static Object fromJson(String json, Class klass) {
-        return (new Gson()).fromJson(json, klass);
+        return gson.fromJson(json, klass);
     }
 
     @Override

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/SshCredentialCollection.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/SshCredentialCollection.java
@@ -26,6 +26,8 @@ import java.util.List;
  */
 public class SshCredentialCollection {
 
+    private static final Gson gson = new Gson();
+
     private List<SshCredential> credentials = new ArrayList<>();
     private Integer count;
 
@@ -38,7 +40,6 @@ public class SshCredentialCollection {
     }
 
     public static Object fromJson(String jsonRecords, Class klass) {
-        Gson gson = new Gson();
         return gson.fromJson(jsonRecords, klass);
     }
 }

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/SshCredentialCreateTmpl.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/SshCredentialCreateTmpl.java
@@ -3,6 +3,7 @@ package com.sixsq.slipstream.credentials;
 import com.google.gson.Gson;
 
 public class SshCredentialCreateTmpl {
+    private static final Gson gson = new Gson();
     public ISshCredential credentialTemplate;
 
     public SshCredentialCreateTmpl(ISshCredential cd) {
@@ -13,12 +14,10 @@ public class SshCredentialCreateTmpl {
     }
 
     public String toJson() {
-        Gson gson = new Gson();
         return gson.toJson(this);
     }
 
     public static SshCredentialCreateTmpl fromJson(String json) {
-        Gson gson = new Gson();
         return gson.fromJson(json, SshCredentialCreateTmpl.class);
     }
 }

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/SshCredentials.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/credentials/SshCredentials.java
@@ -26,6 +26,8 @@ import java.util.List;
  */
 public class SshCredentials {
 
+    private static final Gson gson = new Gson();
+
     private List<ISshCredential> credentials = new ArrayList<>();
     private Integer count;
 
@@ -38,7 +40,6 @@ public class SshCredentials {
     }
 
     public static Object fromJson(String jsonRecords, Class klass) {
-        Gson gson = new Gson();
         return gson.fromJson(jsonRecords, klass);
     }
 }

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/User.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/User.java
@@ -65,6 +65,8 @@ import java.util.logging.Logger;
 @SuppressWarnings("serial")
 public class User extends Metadata {
 
+    private static final Gson gson = new Gson();
+
     private static final String USERNAME = "internal";
     private static final String ROLE = "ADMIN";
     private static final String USERNAME_ROLE = USERNAME + " " + ROLE;
@@ -521,7 +523,7 @@ public class User extends Metadata {
         if (SscljProxy.isError(resp)) {
             return null;
         }
-        User user = (new Gson()).fromJson(resp.getEntityAsText(), User.class);
+        User user = gson.fromJson(resp.getEntityAsText(), User.class);
         if (null == user) {
             return user;
         }
@@ -827,14 +829,14 @@ public class User extends Metadata {
             throw new SlipStreamDatabaseException("Failed to persist User: "
                     + SscljProxy.respToString(resp));
         }
-        User user = (new Gson()).fromJson(resp.getEntityAsText(), User.class);
+        User user = gson.fromJson(resp.getEntityAsText(), User.class);
         if (null == user || null == user.name) {
             resp = SscljProxy.get(SscljProxy.BASE_RESOURCE + resourceUri, USERNAME_ROLE);
             if (SscljProxy.isError(resp) || null == resp.getEntityAsText()) {
                 throw new SlipStreamDatabaseException("Failed to persist User: "
                         + SscljProxy.respToString(resp));
             }
-            user = (new Gson()).fromJson(resp.getEntityAsText(), User.class);
+            user = gson.fromJson(resp.getEntityAsText(), User.class);
         }
         try {
             user.parameters = loadParameters(user);

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/UserGeneralParams.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/UserGeneralParams.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 public class UserGeneralParams {
+    private static final Gson gson = new Gson();
     public Integer timeout = 30;
     public Integer verbosityLevel = Integer.parseInt(ExecutionControlUserParametersFactory.VERBOSITY_LEVEL_DEFAULT);
     public String defaultCloudService = "";
@@ -37,7 +38,7 @@ public class UserGeneralParams {
     }
 
     public static UserGeneralParams fromJson(String jsonRecords) {
-        return (new Gson()).fromJson(jsonRecords, UserGeneralParams.class);
+        return gson.fromJson(jsonRecords, UserGeneralParams.class);
     }
 
     public void setParameter(UserParameter param) {

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/UserGeneralParamsCollection.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/UserGeneralParamsCollection.java
@@ -26,6 +26,8 @@ import java.util.List;
  */
 public class UserGeneralParamsCollection {
 
+    private static final Gson gson = new Gson();
+
     private List<UserGeneralParams> userParam = new ArrayList<>();
     private Integer count;
 
@@ -38,7 +40,6 @@ public class UserGeneralParamsCollection {
     }
 
     public static UserGeneralParamsCollection fromJson(String jsonRecords) {
-        Gson gson = new Gson();
         return gson.fromJson(jsonRecords, UserGeneralParamsCollection.class);
     }
 }

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/UserGeneralParamsTemplate.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/UserGeneralParamsTemplate.java
@@ -3,12 +3,13 @@ package com.sixsq.slipstream.persistence;
 import com.google.gson.Gson;
 
 public class UserGeneralParamsTemplate {
+    private static final Gson gson = new Gson();
     public UserGeneralParams userParamTemplate;
     public UserGeneralParamsTemplate(UserGeneralParams params) {
         this.userParamTemplate = params;
     }
 
     public static UserGeneralParamsTemplate fromJson(String jsonRecords) {
-        return (new Gson()).fromJson(jsonRecords, UserGeneralParamsTemplate.class);
+        return gson.fromJson(jsonRecords, UserGeneralParamsTemplate.class);
     }
 }

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Users.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/Users.java
@@ -26,6 +26,8 @@ import java.util.List;
  */
 public class Users {
 
+    private static final Gson gson = new Gson();
+
     private List<User> users = new ArrayList<>();
 
     public List<User> getUsers() {
@@ -33,7 +35,7 @@ public class Users {
     }
 
     public static Users fromJson(String jsonRecords) {
-        return (new Gson()).fromJson(jsonRecords, Users.class);
+        return gson.fromJson(jsonRecords, Users.class);
     }
 
 

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/UsersView.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/UsersView.java
@@ -27,6 +27,8 @@ import java.util.List;
  */
 public class UsersView {
 
+    private static final Gson gson = new Gson();
+
     private List<UserView> users = new ArrayList<>();
 
     public List<UserView> getUsers() {
@@ -34,7 +36,7 @@ public class UsersView {
     }
 
     public static UsersView fromJson(String jsonRecords) {
-        return (new Gson()).fromJson(jsonRecords, UsersView.class);
+        return gson.fromJson(jsonRecords, UsersView.class);
     }
 
 

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/VirtualMachines.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/VirtualMachines.java
@@ -27,6 +27,8 @@ import java.util.List;
  */
 public class VirtualMachines {
 
+    private static final Gson gson = new Gson();
+
     private List<VirtualMachine> virtualMachines = new ArrayList<>();
 
     public List<VirtualMachine> getVirtualMachines() {
@@ -34,7 +36,6 @@ public class VirtualMachines {
     }
 
     public static VirtualMachines fromJson(String jsonRecords) {
-        Gson gson = new Gson();
         return gson.fromJson(jsonRecords, VirtualMachines.class);
     }
 

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/VmMapping.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/VmMapping.java
@@ -12,6 +12,8 @@ public class VmMapping {
 
     private static final Logger logger = Logger.getLogger(VmMapping.class.getName());
 
+    private static final Gson gson = new Gson();
+
     @SuppressWarnings("unused")
     @SerializedName("cloud")
     private String cloud;
@@ -55,12 +57,10 @@ public class VmMapping {
     }
 
     public String toJson() {
-        Gson gson = new Gson();
         return gson.toJson(this);
     }
 
     public static VmMapping fromJson(String json) {
-        Gson gson = new Gson();
         return gson.fromJson(json, VmMapping.class);
     }
 

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/VmMappingServiceOffer.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/persistence/VmMappingServiceOffer.java
@@ -5,6 +5,8 @@ import com.google.gson.annotations.SerializedName;
 
 public class VmMappingServiceOffer {
 
+    private static final Gson gson = new Gson();
+
     @SuppressWarnings("unused")
     @SerializedName("href")
     private String href;
@@ -17,12 +19,10 @@ public class VmMappingServiceOffer {
     }
 
     public String toJson() {
-        Gson gson = new Gson();
         return gson.toJson(this);
     }
 
     public static VmMappingServiceOffer fromJson(String json) {
-        Gson gson = new Gson();
         return gson.fromJson(json, VmMappingServiceOffer.class);
     }
 

--- a/jar-persistence/src/main/java/com/sixsq/slipstream/util/SscljProxy.java
+++ b/jar-persistence/src/main/java/com/sixsq/slipstream/util/SscljProxy.java
@@ -45,6 +45,22 @@ import java.util.logging.Logger;
 
 public class SscljProxy {
 
+    private static class TestExclStrat implements ExclusionStrategy {
+        public boolean shouldSkipClass(Class<?> arg0) {
+            return false;
+        }
+
+        public boolean shouldSkipField(FieldAttributes f) {
+            return f.getName().equals("jpaVersion");
+        }
+    }
+
+    private static final Gson gson = new GsonBuilder()
+            .registerTypeAdapter(Date.class, new DateTypeAdapter())
+            .setPrettyPrinting()
+            .setExclusionStrategies(new TestExclStrat())
+            .create();
+
     public enum Method {
         GET,
         PUT,
@@ -290,20 +306,6 @@ public class SscljProxy {
     }
 
     public static String toJson(Object obj) {
-        class TestExclStrat implements ExclusionStrategy {
-            public boolean shouldSkipClass(Class<?> arg0) {
-                return false;
-            }
-
-            public boolean shouldSkipField(FieldAttributes f) {
-                return f.getName().equals("jpaVersion");
-            }
-        }
-        Gson gson = new GsonBuilder()
-                .registerTypeAdapter(Date.class, new DateTypeAdapter())
-                .setPrettyPrinting()
-                .setExclusionStrategies(new TestExclStrat())
-                .create();
         return gson.toJson(obj);
     }
 

--- a/jar-service/src/main/java/com/sixsq/slipstream/resource/ResultsDirectory.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/resource/ResultsDirectory.java
@@ -41,6 +41,8 @@ import com.sixsq.slipstream.util.SerializationUtil;
 
 public class ResultsDirectory extends Directory {
 
+    private static final Gson gson = new Gson();
+
     public ResultsDirectory(Context context, Reference rootLocalReference) {
         super(context, rootLocalReference);
         setDefaults();
@@ -89,7 +91,6 @@ public class ResultsDirectory extends Directory {
 
         FilePropertiesList data = new FilePropertiesList(indexContent);
 
-        Gson gson = new Gson();
         String result = gson.toJson(data);
 
         return new StringRepresentation(result, APPLICATION_JSON);

--- a/jar-service/src/main/java/com/sixsq/slipstream/ui/PlacementRequest.java
+++ b/jar-service/src/main/java/com/sixsq/slipstream/ui/PlacementRequest.java
@@ -1,7 +1,6 @@
 package com.sixsq.slipstream.ui;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.sixsq.slipstream.exceptions.ValidationException;
 import com.sixsq.slipstream.persistence.Module;
 import com.sixsq.slipstream.persistence.ModuleCategory;
@@ -21,6 +20,8 @@ import java.util.logging.Logger;
 public class PlacementRequest {
 
     private static Logger logger = Logger.getLogger(PlacementRequest.class.getName());
+
+    private static final Gson gson = new Gson();
 
     private String moduleUri;
 
@@ -74,7 +75,6 @@ public class PlacementRequest {
     }
 
     public static PlacementRequest fromJson(String json) throws ValidationException {
-        Gson gson = new GsonBuilder().create();
         PlacementRequest placementRequest = gson.fromJson(json, PlacementRequest.class);
 
         validateFromJSON(placementRequest);

--- a/jar-service/src/test/java/com/sixsq/slipstream/resource/ResultsDirectoryTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/resource/ResultsDirectoryTest.java
@@ -9,9 +9,9 @@ package com.sixsq.slipstream.resource;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,6 +51,8 @@ import org.xml.sax.SAXException;
 import com.google.gson.Gson;
 
 public class ResultsDirectoryTest {
+
+    private static final Gson gson = new Gson();
 
     @Test
     public void checkDefaultOptions() {
@@ -141,7 +143,6 @@ public class ResultsDirectoryTest {
     }
 
     private static FilePropertiesList isValidJson(String json) {
-        Gson gson = new Gson();
         return gson.fromJson(json, FilePropertiesList.class);
     }
 

--- a/jar-service/src/test/java/com/sixsq/slipstream/ui/UIPlacementResourceTest.java
+++ b/jar-service/src/test/java/com/sixsq/slipstream/ui/UIPlacementResourceTest.java
@@ -1,7 +1,6 @@
 package com.sixsq.slipstream.ui;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.sixsq.slipstream.exceptions.ValidationException;
 import com.sixsq.slipstream.persistence.ImageModule;
 import com.sixsq.slipstream.persistence.Module;
@@ -22,6 +21,8 @@ import static org.junit.Assert.assertThat;
 /**
  */
 public class UIPlacementResourceTest extends ResourceTestBase {
+
+    private static final Gson gson = new Gson();
 
     public static String imageName = "test-image";
     public static String projectName = "test-project";
@@ -85,7 +86,6 @@ public class UIPlacementResourceTest extends ResourceTestBase {
 
         Response response = putUIPlacement(data);
 
-        Gson gson = new GsonBuilder().create();
         System.out.println("RESPONSE: " + response.getEntityAsText());
         Object fromJson = gson.fromJson(response.getEntityAsText(), Object.class);
 


### PR DESCRIPTION
Use status Gson instances to avoid creating many Gson objects during (de)serialization.