### PR TITLE
fix module naming

### DIFF
--- a/token/clj/pom.xml
+++ b/token/clj/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>token</artifactId>
+  <artifactId>token-dep</artifactId>
   <packaging>pom</packaging>
   <version>3.45-SNAPSHOT</version>
   <name>SlipStreamServer/token/clj</name>
@@ -10,7 +10,7 @@
 
   <parent>
     <groupId>com.sixsq.slipstream</groupId>
-    <artifactId>token-dep</artifactId>
+    <artifactId>token-parent</artifactId>
     <version>3.45-SNAPSHOT</version>
   </parent>
 

--- a/token/java/pom.xml
+++ b/token/java/pom.xml
@@ -10,7 +10,7 @@
 
   <parent>
     <groupId>com.sixsq.slipstream</groupId>
-    <artifactId>token-dep</artifactId>
+    <artifactId>token-parent</artifactId>
     <version>3.45-SNAPSHOT</version>
   </parent>
 

--- a/token/pom.xml
+++ b/token/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>token-dep</artifactId>
+  <artifactId>token-parent</artifactId>
   <version>3.45-SNAPSHOT</version>
   <name>SlipStreamServer/token</name>
 


### PR DESCRIPTION
Fix the module naming for the token submodule to prevent conflict in naming artifacts between maven and leiningen.