### PR TITLE
when deleting api key/secret use getRuntimeParameterValueIgnoreAbort()

### DIFF
--- a/jar-connector/src/main/java/com/sixsq/slipstream/connector/CliConnectorBase.java
+++ b/jar-connector/src/main/java/com/sixsq/slipstream/connector/CliConnectorBase.java
@@ -235,8 +235,8 @@ public abstract class CliConnectorBase extends ConnectorBase {
 	public static void deleteApiKeySecret(Run run, User user, Logger log) {
 	    String key = null;
 		try {
-			key = run.getRuntimeParameterValue(RuntimeParameter.GLOBAL_RUN_APIKEY_KEY);
-		} catch (AbortException | NotFoundException e) {
+			key = run.getRuntimeParameterValueIgnoreAbort(RuntimeParameter.GLOBAL_RUN_APIKEY_KEY);
+		} catch (NotFoundException e) {
 			e.printStackTrace();
 		}
 		if (null != key && key.startsWith("credential/")) {


### PR DESCRIPTION
Connected to #1469 