### PR TITLE
specs with ns-qualified keywords

### DIFF
--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/callback.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/callback.cljc
@@ -1,20 +1,19 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.callback
   (:require
     [clojure.spec.alpha :as s]
-    [clojure.spec.gen.alpha :as gen]
-    [clojure.string :as str]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.session-template]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
-(s/def :cimi.callback/action :cimi.core/nonblank-string)
+(s/def :cimi.callback/action ::cimi-core/nonblank-string)
 (s/def :cimi.callback/state #{"WAITING" "FAILED" "SUCCEEDED"})
-(s/def :cimi.callback/targetResource :cimi.common/resource-link)
+(s/def :cimi.callback/targetResource ::cimi-common/resource-link)
 (s/def :cimi.callback/data (su/constrained-map keyword? any?))
-(s/def :cimi.common/expires :cimi.core/timestamp)
+(s/def :cimi.callback/expires ::cimi-core/timestamp)
 
 (s/def :cimi/callback
-  (su/only-keys-maps c/common-attrs
+  (su/only-keys-maps cimi-common/common-attrs
                      {:req-un [:cimi.callback/action
                                :cimi.callback/state
                                :cimi.callback/targetResource]

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/connector.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/connector.cljc
@@ -1,7 +1,4 @@
-(ns com.sixsq.slipstream.ssclj.resources.spec.connector
-  (:require
-    [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.resources.spec.connector-template]))
+(ns com.sixsq.slipstream.ssclj.resources.spec.connector)
 
 ;;
 ;; Note that all of the keys and keys specs are already defined

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/connector_template.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/connector_template.cljc
@@ -1,8 +1,9 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.connector-template
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 ;; Generic type definitions.
 
@@ -20,7 +21,7 @@
 ;; Add these to the connector schema as necessary.
 (s/def :cimi.connector-template/endpoint string?)
 (s/def :cimi.connector-template/objectStoreEndpoint string?)
-(s/def :cimi.connector-template/nativeContextualization :cimi.core/nonblank-string)
+(s/def :cimi.connector-template/nativeContextualization ::cimi-core/nonblank-string)
 (s/def :cimi.connector-template/orchestratorSSHUsername string?)
 (s/def :cimi.connector-template/orchestratorSSHPassword string?)
 (s/def :cimi.connector-template/securityGroups string?)

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/email.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/email.cljc
@@ -1,10 +1,11 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.email
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
-(s/def :cimi.email/address :cimi.core/email)
+(s/def :cimi.email/address ::cimi-core/email)
 (s/def :cimi.email/validated? boolean?)
 
 (s/def :cimi/email

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/event.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/event.cljc
@@ -1,8 +1,9 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.event
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 (s/def :cimi.event/severity #{"critical" "high" "medium" "low"})
 (s/def :cimi.event/type #{"state" "alarm" "action" "system"})
@@ -19,17 +20,17 @@
                                                   :cimi.event/state]))
 
 (s/def :cimi/event
-  (su/only-keys :req-un [:cimi.common/id
-                         :cimi.common/resourceURI
-                         :cimi.common/acl
+  (su/only-keys :req-un [::cimi-common/id
+                         ::cimi-common/resourceURI
+                         ::cimi-common/acl
 
-                         :cimi.core/timestamp
+                         ::cimi-core/timestamp
                          :cimi.event/content
                          :cimi.event/type
                          :cimi.event/severity]
-                :opt-un [:cimi.common/created               ;; FIXME: should be required
-                         :cimi.common/updated               ;; FIXME: should be required
-                         :cimi.common/name
-                         :cimi.common/description
-                         :cimi.common/properties
-                         :cimi.common/operations]))
+                :opt-un [::cimi-common/created              ;; FIXME: should be required
+                         ::cimi-common/updated              ;; FIXME: should be required
+                         ::cimi-common/name
+                         ::cimi-common/description
+                         ::cimi-common/properties
+                         ::cimi-common/operations]))

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/external_object.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/external_object.cljc
@@ -1,15 +1,16 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.external-object
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.resources.spec.common]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]))
 
-(s/def :cimi.external-object/objectType :cimi.core/identifier)
+(s/def :cimi.external-object/objectType ::cimi-core/identifier)
 (s/def :cimi.external-object/state #{"new" "ready"})
-(s/def :cimi.external-object/objectStoreCred :cimi.common/resource-link)
-(s/def :cimi.external-object/objectName :cimi.core/nonblank-string)
-(s/def :cimi.external-object/bucketName :cimi.core/nonblank-string)
+(s/def :cimi.external-object/objectStoreCred ::cimi-common/resource-link)
+(s/def :cimi.external-object/objectName ::cimi-core/nonblank-string)
+(s/def :cimi.external-object/bucketName ::cimi-core/nonblank-string)
 
-(s/def :cimi.external-object/contentType :cimi.core/nonblank-string)
+(s/def :cimi.external-object/contentType ::cimi-core/nonblank-string)
 
 (def external-object-template-regex #"^external-object-template/[a-z]+(-[a-z]+)*$")
 (s/def :cimi.external-object/href (s/and string? #(re-matches external-object-template-regex %)))

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/external_object_generic.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/external_object_generic.cljc
@@ -2,8 +2,8 @@
   (:require
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.external-object :as eo]))
+    [com.sixsq.slipstream.ssclj.resources.spec.external-object :as eo]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 (def external-object-generic-keys-spec eo/external-object-keys-spec)
 

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/external_object_report.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/external_object_report.cljc
@@ -2,11 +2,12 @@
   (:require
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.external-object :as eo]))
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.resources.spec.external-object :as eo]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
-(s/def :cimi.external-object.report/runUUID :cimi.core/nonblank-string)
-(s/def :cimi.external-object.report/component :cimi.core/nonblank-string)
+(s/def :cimi.external-object.report/runUUID ::cimi-core/nonblank-string)
+(s/def :cimi.external-object.report/component ::cimi-core/nonblank-string)
 
 (def external-object-report-keys-spec
   (su/merge-keys-specs [eo/external-object-keys-spec

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/external_object_template_generic.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/external_object_template_generic.cljc
@@ -3,8 +3,8 @@
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.external-object :as eo]))
+    [com.sixsq.slipstream.ssclj.resources.spec.external-object :as eo]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 
 (def template-resource-keys-spec

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/external_object_template_report.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/external_object_template_report.cljc
@@ -3,9 +3,10 @@
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.resources.spec.external-object-report :as eor]
     [com.sixsq.slipstream.ssclj.resources.spec.external-object]
-    [com.sixsq.slipstream.ssclj.resources.spec.external-object-report :as eor]))
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 
 (def template-resource-keys-spec
@@ -14,7 +15,7 @@
                                                        :cimi.external-object/bucketName
                                                        :cimi.external-object/objectStoreCred}))
 
-(s/def :cimi.external-object-template.report/filename :cimi.core/nonblank-string)
+(s/def :cimi.external-object-template.report/filename ::cimi-core/nonblank-string)
 
 ;; Defines the contents of the generic template used in a create resource.
 ;; NOTE: The name must match the key defined by the resource, :externalObjectTemplate here.

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/job.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/job.cljc
@@ -1,28 +1,28 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.job
   (:require
     [clojure.spec.alpha :as s]
-    [instaparse.core :as insta]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
-    [com.sixsq.slipstream.ssclj.filter.parser :as parser]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.resources.spec.common-operation :as cimi-common-operation]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 (def job-href-regex #"^job/[a-z]+(-[a-z]+)*$")
 (s/def :cimi.job/href (s/and string? #(re-matches job-href-regex %)))
 
 (s/def :cimi.job/state #{"QUEUED" "RUNNING" "FAILED" "SUCCESS" "STOPPING" "STOPPED"})
-(s/def :cimi.job/targetResource :cimi.common/resource-link)
-(s/def :cimi.job/affectedResources :cimi.common/resource-links)
+(s/def :cimi.job/targetResource ::cimi-common/resource-link)
+(s/def :cimi.job/affectedResources ::cimi-common/resource-links)
 (s/def :cimi.job/returnCode int?)
 (s/def :cimi.job/progress (s/int-in 0 101))
-(s/def :cimi.job/timeOfStatusChange :cimi.core/timestamp)
+(s/def :cimi.job/timeOfStatusChange ::cimi-core/timestamp)
 (s/def :cimi.job/statusMessage string?)
-(s/def :cimi.job/action :cimi.common.operation/rel)
+(s/def :cimi.job/action ::cimi-common-operation/rel)
 (s/def :cimi.job/parentJob :cimi.job/href)
 (s/def :cimi.job/nestedJobs (s/coll-of :cimi.job/href))
 
 
 (s/def :cimi/job
-  (su/only-keys-maps c/common-attrs
+  (su/only-keys-maps cimi-common/common-attrs
                      {:req-un [:cimi.job/state
                                :cimi.job/action
                                :cimi.job/progress]

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/metering.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/metering.cljc
@@ -1,12 +1,13 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.metering
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
-    [com.sixsq.slipstream.ssclj.resources.spec.virtual-machine :as vm]))
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.resources.spec.virtual-machine :as vm]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 
-(s/def :cimi.metering/snapshot-time :cimi.core/timestamp)
+(s/def :cimi.metering/snapshot-time ::cimi-core/timestamp)
 
 
 (def metering-keys-spec (su/merge-keys-specs [c/common-attrs

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/quota.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/quota.cljc
@@ -2,9 +2,10 @@
   (:require
     [clojure.spec.alpha :as s]
     [instaparse.core :as insta]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.filter.parser :as parser]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
-    [com.sixsq.slipstream.ssclj.filter.parser :as parser]))
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 
 (defn valid-cimi-filter?
@@ -14,9 +15,9 @@
     (catch Throwable _ false)))
 
 
-(s/def :cimi.quota/resource :cimi.core/nonblank-string)
+(s/def :cimi.quota/resource ::cimi-core/nonblank-string)
 (s/def :cimi.quota/selection valid-cimi-filter?)
-(s/def :cimi.quota/aggregation :cimi.core/nonblank-string)
+(s/def :cimi.quota/aggregation ::cimi-core/nonblank-string)
 (s/def :cimi.quota/limit pos-int?)
 
 

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/service_attribute.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/service_attribute.cljc
@@ -3,8 +3,9 @@
     [clojure.spec.alpha :as s]
     [clojure.spec.gen.alpha :as gen]
     [clojure.string :as str]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 (def prefix-regex #"^[a-z]([a-z0-9-]*[a-z0-9])?$")
 (def char-prefix (gen/fmap char (s/gen (set (concat (range 97 123) (range 48 58) [45])))))
@@ -12,14 +13,14 @@
 (s/def :cimi.service-attribute/prefix (s/with-gen (s/and string? #(re-matches prefix-regex %))
                                                   (constantly gen-prefix)))
 
-(s/def :cimi.service-attribute/attributeName :cimi.core/nonblank-string)
+(s/def :cimi.service-attribute/attributeName ::cimi-core/nonblank-string)
 
-(s/def :cimi.service-attribute/type :cimi.core/nonblank-string)
+(s/def :cimi.service-attribute/type ::cimi-core/nonblank-string)
 
 (s/def :cimi/service-attribute
-  (su/only-keys-maps c/common-attrs
-                     {:req-un [:cimi.common/name            ;; name is required
-                               :cimi.common/description     ;; description is required
+  (su/only-keys-maps cimi-common/common-attrs
+                     {:req-un [::cimi-common/name           ;; name is required
+                               ::cimi-common/description    ;; description is required
                                :cimi.service-attribute/prefix
                                :cimi.service-attribute/attributeName
                                :cimi.service-attribute/type]}))

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/service_attribute_namespace.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/service_attribute_namespace.cljc
@@ -3,8 +3,9 @@
     [clojure.spec.alpha :as s]
     [clojure.spec.gen.alpha :as gen]
     [clojure.string :as str]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 (def prefix-regex #"^[a-z]([a-z0-9-]*[a-z0-9])?$")
 (def char-prefix (gen/fmap char (s/gen (set (concat (range 97 123) (range 48 58) [45])))))
@@ -15,4 +16,4 @@
 (s/def :cimi/service-attribute-namespace
   (su/only-keys-maps c/common-attrs
                      {:req-un [:cimi.service-attribute-namespace/prefix
-                               :cimi.core/uri]}))
+                               ::cimi-core/uri]}))

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/service_benchmark.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/service_benchmark.cljc
@@ -1,15 +1,15 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.service-benchmark
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 
-(s/def :cimi.service-benchmark/credentials (s/coll-of :cimi.common/resource-link))
-(s/def :cimi.service-benchmark/serviceOffer :cimi.common/resource-link)
+(s/def :cimi.service-benchmark/credentials (s/coll-of ::cimi-common/resource-link))
+(s/def :cimi.service-benchmark/serviceOffer ::cimi-common/resource-link)
 
 (s/def :cimi/service-benchmark
   (su/constrained-map keyword? any?
-                      c/common-attrs
+                      cimi-common/common-attrs
                       {:req-un [:cimi.service-benchmark/credentials
                                 :cimi.service-benchmark/serviceOffer]}))

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/service_offer.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/service_offer.cljc
@@ -1,9 +1,9 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.service-offer
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
-    [com.sixsq.slipstream.ssclj.resources.spec.connector-template]))
+    [com.sixsq.slipstream.ssclj.resources.spec.connector-template]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 ;;
 ;; Must reference the raw name of the connector.  Reference the schema

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/user_template_self_registration.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/user_template_self_registration.cljc
@@ -1,8 +1,8 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.user-template-self-registration
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.resources.spec.user]
     [com.sixsq.slipstream.ssclj.resources.spec.user-template :as ps]
+    [com.sixsq.slipstream.ssclj.resources.spec.user]
     [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/virtual_machine.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/virtual_machine.cljc
@@ -1,17 +1,18 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.virtual-machine
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
-(s/def :cimi.virtual-machine/href :cimi.core/nonblank-string)
-(s/def :cimi.virtual-machine/credentials (s/coll-of (s/keys :req-un [:cimi.virtual-machine/href]))) ; TODO: switch to :cimi.common/resource-links when credential resource will be in use
-(s/def :cimi.virtual-machine/instanceID :cimi.core/nonblank-string)
-(s/def :cimi.virtual-machine/state :cimi.core/nonblank-string)
-(s/def :cimi.virtual-machine/ip :cimi.core/nonblank-string)
-(s/def :cimi.virtual-machine/connector :cimi.common/resource-link)
-(s/def :cimi.virtual-machine/serviceOffer :cimi.common/resource-link)
-(s/def :cimi.virtual-machine/deployment :cimi.common/resource-link)
+(s/def :cimi.virtual-machine/href ::cimi-core/nonblank-string)
+(s/def :cimi.virtual-machine/credentials (s/coll-of (s/keys :req-un [:cimi.virtual-machine/href]))) ; TODO: switch to ::cimi-common/resource-links when credential resource will be in use
+(s/def :cimi.virtual-machine/instanceID ::cimi-core/nonblank-string)
+(s/def :cimi.virtual-machine/state ::cimi-core/nonblank-string)
+(s/def :cimi.virtual-machine/ip ::cimi-core/nonblank-string)
+(s/def :cimi.virtual-machine/connector ::cimi-common/resource-link)
+(s/def :cimi.virtual-machine/serviceOffer ::cimi-common/resource-link)
+(s/def :cimi.virtual-machine/deployment ::cimi-common/resource-link)
 
 (def virtual-machine-specs {:req-un [:cimi.virtual-machine/credentials
                                      :cimi.virtual-machine/instanceID
@@ -21,7 +22,7 @@
                                      :cimi.virtual-machine/serviceOffer
                                      :cimi.virtual-machine/ip]})
 
-(def virtual-machine-keys-spec (su/merge-keys-specs [c/common-attrs
+(def virtual-machine-keys-spec (su/merge-keys-specs [cimi-common/common-attrs
                                                      virtual-machine-specs]))
 
 (s/def :cimi/virtual-machine (su/only-keys-maps virtual-machine-keys-spec))

--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/virtual_machine_mapping.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/virtual_machine_mapping.cljc
@@ -1,15 +1,16 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.virtual-machine-mapping
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
-(s/def :cimi.virtual-machine-mapping/cloud :cimi.core/nonblank-string)
-(s/def :cimi.virtual-machine-mapping/instanceID :cimi.core/nonblank-string)
+(s/def :cimi.virtual-machine-mapping/cloud ::cimi-core/nonblank-string)
+(s/def :cimi.virtual-machine-mapping/instanceID ::cimi-core/nonblank-string)
 
-(s/def :cimi.virtual-machine-mapping/runUUID :cimi.core/nonblank-string)
-(s/def :cimi.virtual-machine-mapping/owner :cimi.core/nonblank-string)
-(s/def :cimi.virtual-machine-mapping/serviceOffer :cimi.common/resource-link)
+(s/def :cimi.virtual-machine-mapping/runUUID ::cimi-core/nonblank-string)
+(s/def :cimi.virtual-machine-mapping/owner ::cimi-core/nonblank-string)
+(s/def :cimi.virtual-machine-mapping/serviceOffer ::cimi-common/resource-link)
 
 (def virtual-machine-mapping-specs {:req-un [:cimi.virtual-machine-mapping/cloud
                                              :cimi.virtual-machine-mapping/instanceID]
@@ -17,7 +18,7 @@
                                              :cimi.virtual-machine-mapping/owner
                                              :cimi.virtual-machine-mapping/serviceOffer]})
 
-(def virtual-machine-mapping-keys-spec (su/merge-keys-specs [c/common-attrs
+(def virtual-machine-mapping-keys-spec (su/merge-keys-specs [cimi-common/common-attrs
                                                              virtual-machine-mapping-specs]))
 
 (s/def :cimi/virtual-machine-mapping (su/only-keys-maps virtual-machine-mapping-keys-spec))

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/acl.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/acl.cljc
@@ -1,0 +1,27 @@
+(ns com.sixsq.slipstream.ssclj.resources.spec.acl
+  "Access Control Lists (an extension to the CIMI standard)."
+  (:require
+    [clojure.spec.alpha :as s]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]))
+
+
+(s/def ::principal ::cimi-core/nonblank-string)
+
+(s/def ::type #{"USER" "ROLE"})
+(s/def ::right #{"VIEW" "MODIFY"                            ;; LEGACY RIGHTS
+                 "ALL"
+                 "VIEW_ACL" "VIEW_DATA" "VIEW_META"
+                 "EDIT_ACL" "EDIT_DATA" "EDIT_META"
+                 "DELETE"
+                 "MANAGE"})
+
+(s/def ::owner (su/only-keys :req-un [::principal
+                                      ::type]))
+
+(s/def ::rule (su/only-keys :req-un [::principal
+                                     ::type
+                                     ::right]))
+(s/def ::rules (s/coll-of ::rule :min-count 1))
+
+

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/cloud_entry_point.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/cloud_entry_point.cljc
@@ -1,12 +1,13 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.cloud-entry-point
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
     [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
-(s/def :cimi.cloud-entry-point/baseURI :cimi.core/nonblank-string)
+(s/def :cimi.cloud-entry-point/baseURI ::cimi-core/nonblank-string)
 
 (s/def :cimi/cloud-entry-point
-  (su/constrained-map keyword? :cimi.common/resource-link
-                      c/common-attrs
+  (su/constrained-map keyword? ::cimi-common/resource-link
+                      cimi-common/common-attrs
                       {:req-un [:cimi.cloud-entry-point/baseURI]}))

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/common.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/common.cljc
@@ -1,174 +1,78 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.common
-  "Spec definitions for basic types and common types used in CIMI
-   resources."
+  "Spec definitions for common types used in CIMI resources."
   (:require
-    [clojure.set :as set]
     [clojure.spec.alpha :as s]
-    [clojure.spec.gen.alpha :as gen]
-    [clojure.string :as str]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.common.utils :as cu]))
-
-;;
-;; basic types
-;; keep all these definitions in the 'cimi.core' namespace
-;;
-
-(s/def :cimi.core/nonblank-string (s/and string? (complement str/blank?)))
-
-(defn token? [s] (re-matches #"^\S+$" s))
-(s/def :cimi.core/token (s/and string? token?))
-
-(s/def :cimi.core/port (s/int-in 1 65536))
-
-;; FIXME: Provide an implementation that works with ClojureScript.
-(s/def :cimi.core/timestamp (s/with-gen (s/and string? cu/as-datetime)
-                                        (constantly (gen/fmap cu/unparse-timestamp-date (gen/gen-for-pred inst?)))))
-
-;; FIXME: Remove this definition when resources treat the timestamp as optional rather than allowing an empty value.
-(s/def :cimi.core/optional-timestamp (s/or :empty #{""} :not-empty :cimi.core/timestamp))
-
-;; FIXME: Replace this spec with one that enforces the URI grammar.
-(s/def :cimi.core/uri :cimi.core/nonblank-string)
-
-;; A username can only consist of letters, digits and underscores.
-(s/def :cimi.core/username
-  (su/regex-string #"[a-zA-Z0-9_]" #"^[a-zA-Z0-9_]+$"))
-
-;; A kebab identifier consists of lowercased words separated by dashes.
-(s/def :cimi.core/kebab-identifier
-  (su/regex-string #"[a-z-]" #"^[a-z]+(-[a-z]+)*$"))
-
-;; A resource identifier consists of words of letters and digits separated
-;; by underscores or dashes.
-(s/def :cimi.core/resource-identifier
-  (su/regex-string #"[a-zA-Z0-9_-]" #"^[a-zA-Z0-9]+([_-][a-zA-Z0-9]+)*$"))
-
-;; Words consisting of lowercase letters and digits, separated by dashes.
-(s/def :cimi.core/identifier
-  (su/regex-string #"[a-z0-9-]" #"^[a-z0-9]+(-[a-z0-9]+)*$"))
-
-(s/def :cimi.core/resource-type :cimi.core/kebab-identifier)
-
-;; Email address verifier.
-(def email-regex #"^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
-(defn email? [s] (re-matches email-regex s))
-(s/def :cimi.core/email
-  (s/and string? email?))
-
-;;
-;; A resource href is the concatenation of a resource type and resource identifier separated
-;; with a slash.  The later part is optional for singleton resources like the cloud-entry-point.
-;;
-(defn- join-href-parts
-  [[resource-type resource-identifier]]
-  (if resource-identifier
-    (str resource-type "/" resource-identifier)
-    resource-type))
-
-(def resource-href-regex #"^[a-z]([a-z-]*[a-z])?(/[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?)?$")
-(s/def :cimi.core/resource-href
-  (s/with-gen (s/and string? #(re-matches resource-href-regex %))
-              (constantly (gen/fmap join-href-parts
-                                    (gen/tuple
-                                      (s/gen :cimi.core/kebab-identifier)
-                                      (gen/frequency [[95 (s/gen :cimi.core/resource-identifier)]
-                                                      [5 (s/gen #{nil})]]))))))
+    [com.sixsq.slipstream.ssclj.resources.spec.acl :as cimi-acl]
+    [com.sixsq.slipstream.ssclj.resources.spec.common-operation :as cimi-common-operation]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 ;;
 ;; common CIMI attributes
-;; all these definitions are the 'cimi.common' namespace
-;; sub-attributes are in child namespaces of 'cimi.common'
 ;;
 
 ;; simple attributes
-(s/def :cimi.common/id :cimi.core/resource-href)
-(s/def :cimi.common/resourceURI :cimi.core/uri)
-(s/def :cimi.common/created :cimi.core/timestamp)
-(s/def :cimi.common/updated :cimi.core/timestamp)
-(s/def :cimi.common/name :cimi.core/nonblank-string)
-(s/def :cimi.common/description :cimi.core/nonblank-string)
+(s/def ::id ::cimi-core/resource-href)
+(s/def ::resourceURI ::cimi-core/uri)
+(s/def ::created ::cimi-core/timestamp)
+(s/def ::updated ::cimi-core/timestamp)
+(s/def ::name ::cimi-core/nonblank-string)
+(s/def ::description ::cimi-core/nonblank-string)
 
 ;; links between resources
-(s/def :cimi.common.link/href :cimi.core/resource-href)
-(s/def :cimi.common/resource-link (s/keys :req-un [:cimi.common.link/href]))
-(s/def :cimi.common/resource-links (s/coll-of :cimi.common/resource-link :min-count 1))
+(s/def ::href ::cimi-core/resource-href)
+(s/def ::resource-link (s/keys :req-un [::href]))
+(s/def ::resource-links (s/coll-of ::resource-link :min-count 1))
 
 ;; resource operations
-(s/def :cimi.common.operation/href :cimi.core/nonblank-string)
-(s/def :cimi.common.operation/rel :cimi.core/nonblank-string)
-(s/def :cimi.common/operation (su/only-keys :req-un [:cimi.common.operation/href
-                                                     :cimi.common.operation/rel]))
-(s/def :cimi.common/operations (s/coll-of :cimi.common/operation :min-count 1))
+(s/def ::operation (su/only-keys :req-un [::cimi-common-operation/href
+                                          ::cimi-common-operation/rel]))
+(s/def ::operations (s/coll-of ::operation :min-count 1))
 
 ;; client-controlled properties
-(s/def :cimi.common/kw-or-str (s/or :keyword keyword? :string :cimi.core/nonblank-string))
-(s/def :cimi.common/properties (s/map-of :cimi.common/kw-or-str string? :min-count 1))
+(s/def ::kw-or-str (s/or :keyword keyword? :string ::cimi-core/nonblank-string))
+(s/def ::properties (s/map-of ::kw-or-str string? :min-count 1))
 
-
-;;
-;; Access Control Lists (an extension to the CIMI standard)
-;; these definitions are the 'cimi.acl' namespace
-;;
-
-(s/def :cimi.acl/principal :cimi.core/nonblank-string)
-
-(s/def :cimi.acl/type #{"USER" "ROLE"})
-(s/def :cimi.acl/right #{"VIEW" "MODIFY"                    ;; LEGACY RIGHTS
-                         "ALL"
-                         "VIEW_ACL" "VIEW_DATA" "VIEW_META"
-                         "EDIT_ACL" "EDIT_DATA" "EDIT_META"
-                         "DELETE"
-                         "MANAGE"})
-
-(s/def :cimi.acl/owner (su/only-keys :req-un [:cimi.acl/principal
-                                              :cimi.acl/type]))
-
-(s/def :cimi.acl/rule (su/only-keys :req-un [:cimi.acl/principal
-                                             :cimi.acl/type
-                                             :cimi.acl/right]))
-(s/def :cimi.acl/rules (s/coll-of :cimi.acl/rule :min-count 1))
-
-(s/def :cimi.common/acl (su/only-keys :req-un [:cimi.acl/owner]
-                                      :opt-un [:cimi.acl/rules]))
+(s/def ::acl (su/only-keys :req-un [::cimi-acl/owner]
+                           :opt-un [::cimi-acl/rules]))
 
 (def ^:const common-attrs
   "clojure.spec/keys specification (as a map) for common CIMI attributes
    for regular resources"
-  {:req-un [:cimi.common/id
-            :cimi.common/resourceURI
-            :cimi.common/created
-            :cimi.common/updated
-            :cimi.common/acl]
-   :opt-un [:cimi.common/name
-            :cimi.common/description
-            :cimi.common/properties
-            :cimi.common/operations]})
+  {:req-un [::id
+            ::resourceURI
+            ::created
+            ::updated
+            ::acl]
+   :opt-un [::name
+            ::description
+            ::properties
+            ::operations]})
 
 (def ^:const create-attrs
   "clojure.spec/keys specification (as a map) for common CIMI attributes
    for the 'create' resources used when creating resources from a template.
    This applies to the create wrapper and not the embedded resource
    template!"
-  {:req-un [:cimi.common/resourceURI]
-   :opt-un [:cimi.common/name
-            :cimi.common/description
-            :cimi.common/created
-            :cimi.common/updated
-            :cimi.common/properties
-            :cimi.common/operations
-            :cimi.common/acl]})
+  {:req-un [::resourceURI]
+   :opt-un [::name
+            ::description
+            ::created
+            ::updated
+            ::properties
+            ::operations
+            ::acl]})
 
 (def ^:const template-attrs
   "The clojure.spec/keys specification (as a map) for common CIMI attributes
    for the resource templates that are embedded in 'create' resources. Although
    these may be added to the templates (usually by reference), they will have
    no affect on the created resource."
-  {:opt-un [:cimi.common/resourceURI
-            :cimi.common/name
-            :cimi.common/description
-            :cimi.common/created
-            :cimi.common/updated
-            :cimi.common/properties
-            :cimi.common/operations
-            :cimi.common/acl]})
+  {:opt-un [::resourceURI
+            ::name
+            ::description
+            ::created
+            ::updated
+            ::properties
+            ::operations
+            ::acl]})

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/common_operation.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/common_operation.cljc
@@ -1,0 +1,9 @@
+(ns com.sixsq.slipstream.ssclj.resources.spec.common-operation
+  "Spec definitions for common operation types used in CIMI resources."
+  (:require
+    [clojure.spec.alpha :as s]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]))
+
+;; resource operations
+(s/def ::href ::cimi-core/nonblank-string)
+(s/def ::rel ::cimi-core/nonblank-string)

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template.cljc
@@ -2,12 +2,13 @@
   (:require
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
 
 ;; Parameter definitions.
 
-(s/def :cimi.configuration-template/service :cimi.core/identifier)
-(s/def :cimi.configuration-template/instance :cimi.core/identifier)
+(s/def :cimi.configuration-template/service  ::cimi-core/identifier)
+(s/def :cimi.configuration-template/instance ::cimi-core/identifier)
 
 (def configuration-template-regex #"^configuration-template/[a-z0-9]+(-[a-z0-9]+)*$")
 (s/def :cimi.configuration-template/href (s/and string? #(re-matches configuration-template-regex %)))

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template_session_github.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template_session_github.cljc
@@ -2,10 +2,11 @@
   (:require
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.configuration-template :as ps]))
 
-(s/def :cimi.configuration-template.session-github/clientID :cimi.core/token)
-(s/def :cimi.configuration-template.session-github/clientSecret :cimi.core/token)
+(s/def :cimi.configuration-template.session-github/clientID ::cimi-core/token)
+(s/def :cimi.configuration-template.session-github/clientSecret ::cimi-core/token)
 
 (def configuration-template-keys-spec-req
   {:req-un [:cimi.configuration-template/instance

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template_session_oidc.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template_session_oidc.cljc
@@ -2,11 +2,12 @@
   (:require
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.configuration-template :as ps]))
 
-(s/def :cimi.configuration-template.session-oidc/clientID :cimi.core/token)
-(s/def :cimi.configuration-template.session-oidc/baseURL :cimi.core/token)
-(s/def :cimi.configuration-template.session-oidc/publicKey :cimi.core/token)
+(s/def :cimi.configuration-template.session-oidc/clientID ::cimi-core/token)
+(s/def :cimi.configuration-template.session-oidc/baseURL ::cimi-core/token)
+(s/def :cimi.configuration-template.session-oidc/publicKey ::cimi-core/token)
 
 (def configuration-template-keys-spec-req
   {:req-un [:cimi.configuration-template/instance

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template_slipstream.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template_slipstream.cljc
@@ -2,32 +2,33 @@
     (:require
       [clojure.spec.alpha :as s]
       [com.sixsq.slipstream.ssclj.util.spec :as su]
+      [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
       [com.sixsq.slipstream.ssclj.resources.spec.configuration-template :as ps]))
 
-(s/def :cimi.configuration-template.slipstream/slipstreamVersion :cimi.core/nonblank-string)
-(s/def :cimi.configuration-template.slipstream/serviceURL :cimi.core/nonblank-string)
-(s/def :cimi.configuration-template.slipstream/reportsLocation :cimi.core/nonblank-string)
-(s/def :cimi.configuration-template.slipstream/supportEmail :cimi.core/nonblank-string)
-(s/def :cimi.configuration-template.slipstream/clientBootstrapURL :cimi.core/nonblank-string)
-(s/def :cimi.configuration-template.slipstream/clientURL :cimi.core/nonblank-string)
-(s/def :cimi.configuration-template.slipstream/connectorOrchPrivateSSHKey :cimi.core/nonblank-string)
-(s/def :cimi.configuration-template.slipstream/connectorOrchPublicSSHKey :cimi.core/nonblank-string)
-(s/def :cimi.configuration-template.slipstream/connectorLibcloudURL :cimi.core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/slipstreamVersion ::cimi-core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/serviceURL ::cimi-core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/reportsLocation ::cimi-core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/supportEmail ::cimi-core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/clientBootstrapURL ::cimi-core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/clientURL ::cimi-core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/connectorOrchPrivateSSHKey ::cimi-core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/connectorOrchPublicSSHKey ::cimi-core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/connectorLibcloudURL ::cimi-core/nonblank-string)
 
-(s/def :cimi.configuration-template.slipstream/mailUsername :cimi.core/nonblank-string)
-(s/def :cimi.configuration-template.slipstream/mailPassword :cimi.core/nonblank-string)
-(s/def :cimi.configuration-template.slipstream/mailHost :cimi.core/nonblank-string)
-(s/def :cimi.configuration-template.slipstream/mailPort :cimi.core/port)
+(s/def :cimi.configuration-template.slipstream/mailUsername ::cimi-core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/mailPassword ::cimi-core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/mailHost ::cimi-core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/mailPort ::cimi-core/port)
 (s/def :cimi.configuration-template.slipstream/mailSSL boolean?)
 (s/def :cimi.configuration-template.slipstream/mailDebug boolean?)
 
 (s/def :cimi.configuration-template.slipstream/quotaEnable boolean?)
 
 (s/def :cimi.configuration-template.slipstream/registrationEnable boolean?)
-(s/def :cimi.configuration-template.slipstream/registrationEmail :cimi.core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/registrationEmail ::cimi-core/nonblank-string)
 
 (s/def :cimi.configuration-template.slipstream/meteringEnable boolean?)
-(s/def :cimi.configuration-template.slipstream/meteringEndpoint :cimi.core/nonblank-string)
+(s/def :cimi.configuration-template.slipstream/meteringEndpoint ::cimi-core/nonblank-string)
 
 (s/def :cimi.configuration-template.slipstream/serviceCatalogEnable boolean?)
 

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/core.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/core.cljc
@@ -1,0 +1,74 @@
+(ns com.sixsq.slipstream.ssclj.resources.spec.core
+  "Spec definitions for basic types used in CIMI resources."
+  (:require
+    [clojure.spec.alpha :as s]
+    [clojure.spec.gen.alpha :as gen]
+    [clojure.string :as str]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.common.utils :as cu]))
+
+;;
+;; basic types
+;;
+
+(s/def ::nonblank-string (s/and string? (complement str/blank?)))
+
+(defn token? [s] (re-matches #"^\S+$" s))
+(s/def ::token (s/and string? token?))
+
+(s/def ::port (s/int-in 1 65536))
+
+;; FIXME: Provide an implementation that works with ClojureScript.
+(s/def ::timestamp (s/with-gen (s/and string? cu/as-datetime)
+                               (constantly (gen/fmap cu/unparse-timestamp-date (gen/gen-for-pred inst?)))))
+
+;; FIXME: Remove this definition when resources treat the timestamp as optional rather than allowing an empty value.
+(s/def ::optional-timestamp (s/or :empty #{""} :not-empty ::timestamp))
+
+;; FIXME: Replace this spec with one that enforces the URI grammar.
+(s/def ::uri ::nonblank-string)
+
+;; A username can only consist of letters, digits and underscores.
+(s/def ::username
+  (su/regex-string #"[a-zA-Z0-9_]" #"^[a-zA-Z0-9_]+$"))
+
+;; A kebab identifier consists of lowercased words separated by dashes.
+(s/def ::kebab-identifier
+  (su/regex-string #"[a-z-]" #"^[a-z]+(-[a-z]+)*$"))
+
+;; A resource identifier consists of words of letters and digits separated
+;; by underscores or dashes.
+(s/def ::resource-identifier
+  (su/regex-string #"[a-zA-Z0-9_-]" #"^[a-zA-Z0-9]+([_-][a-zA-Z0-9]+)*$"))
+
+;; Words consisting of lowercase letters and digits, separated by dashes.
+(s/def ::identifier
+  (su/regex-string #"[a-z0-9-]" #"^[a-z0-9]+(-[a-z0-9]+)*$"))
+
+(s/def ::resource-type ::kebab-identifier)
+
+;; Email address verifier.
+(def email-regex #"^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+(defn email? [s] (re-matches email-regex s))
+(s/def ::email
+  (s/and string? email?))
+
+;;
+;; A resource href is the concatenation of a resource type and resource identifier separated
+;; with a slash.  The later part is optional for singleton resources like the cloud-entry-point.
+;;
+(defn- join-href-parts
+  [[resource-type resource-identifier]]
+  (if resource-identifier
+    (str resource-type "/" resource-identifier)
+    resource-type))
+
+(def resource-href-regex #"^[a-z]([a-z-]*[a-z])?(/[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?)?$")
+(s/def ::resource-href
+  (s/with-gen (s/and string? #(re-matches resource-href-regex %))
+              (constantly (gen/fmap join-href-parts
+                                    (gen/tuple
+                                      (s/gen ::kebab-identifier)
+                                      (gen/frequency [[95 (s/gen ::resource-identifier)]
+                                                      [5 (s/gen #{nil})]]))))))
+

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/credential_api_key.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/credential_api_key.cljc
@@ -2,17 +2,18 @@
   (:require
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.credential :as cred]
     [com.sixsq.slipstream.ssclj.resources.spec.credential-template-api-key]
     [com.sixsq.slipstream.ssclj.resources.spec.credential-template :as ps]))
 
-(s/def :cimi.credential.api-key/expiry :cimi.core/timestamp)
+(s/def :cimi.credential.api-key/expiry ::cimi-core/timestamp)
 
-(s/def :cimi.credential.api-key/digest :cimi.core/nonblank-string)
+(s/def :cimi.credential.api-key/digest ::cimi-core/nonblank-string)
 
-(s/def :cimi.credential.api-key/identity :cimi.core/nonblank-string)
+(s/def :cimi.credential.api-key/identity ::cimi-core/nonblank-string)
 
-(s/def :cimi.credential.api-key/roles (s/coll-of :cimi.core/nonblank-string
+(s/def :cimi.credential.api-key/roles (s/coll-of ::cimi-core/nonblank-string
                                                  :kind vector?
                                                  :into []
                                                  :min-count 1))

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/credential_template.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/credential_template.cljc
@@ -4,14 +4,15 @@
     [clojure.spec.gen.alpha :as gen]
     [clojure.string :as str]
     [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
 
 ;; All credential templates must indicate the type of credential to create.
-(s/def :cimi.credential-template/type :cimi.core/identifier)
+(s/def :cimi.credential-template/type ::cimi-core/identifier)
 
 ;; A given credential may have more than one method for creating it.  All
 ;; credential templates must provide a method name.
-(s/def :cimi.credential-template/method :cimi.core/identifier)
+(s/def :cimi.credential-template/method ::cimi-core/identifier)
 
 (def credential-template-regex #"^credential-template/[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$")
 (s/def :cimi.credential-template/href (s/and string? #(re-matches credential-template-regex %)))

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/credential_template_cloud.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/credential_template_cloud.cljc
@@ -1,17 +1,15 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.credential-template-cloud
   (:require
     [clojure.spec.alpha :as s]
-    [clojure.spec.gen.alpha :as gen]
-    [clojure.string :as str]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]))
 
 ; FIXME: see https://github.com/slipstream/SlipStreamServer/issues/1309
 (s/def :cimi.credential-template.cloud/key string?)
 (s/def :cimi.credential-template.cloud/secret string?)
-;(s/def :cimi.credential-template.cloud/key :cimi.core/nonblank-string)
-;(s/def :cimi.credential-template.cloud/secret :cimi.core/nonblank-string)
-(s/def :cimi.credential-template.cloud/connector :cimi.common/resource-link)
+;(s/def :cimi.credential-template.cloud/key ::cimi-core/nonblank-string)
+;(s/def :cimi.credential-template.cloud/secret ::cimi-core/nonblank-string)
+(s/def :cimi.credential-template.cloud/connector ::cimi-common/resource-link)
 (s/def :cimi.credential-template.cloud/quota (s/or :pos-int pos-int? :zero zero?))
 
 (def credential-template-cloud-keys-spec

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/credential_template_ssh_public_key.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/credential_template_ssh_public_key.cljc
@@ -2,9 +2,10 @@
   (:require
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.credential-template :as ps]))
 
-(s/def :cimi.credential-template.ssh-public-key/publicKey :cimi.core/nonblank-string)
+(s/def :cimi.credential-template.ssh-public-key/publicKey ::cimi-core/nonblank-string)
 
 (def credential-template-keys-spec
   {:req-un [:cimi.credential-template.ssh-public-key/publicKey]})

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/description.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/description.cljc
@@ -4,7 +4,8 @@
    of resources."
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.resources.spec.common]
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 ;;
@@ -12,15 +13,15 @@
 ;; these definitions are the 'cimi.desc' namespace
 ;;
 
-(s/def :cimi.desc/displayName :cimi.core/nonblank-string)
-(s/def :cimi.desc/category :cimi.core/nonblank-string)
-(s/def :cimi.desc/description :cimi.core/nonblank-string)
+(s/def :cimi.desc/displayName ::cimi-core/nonblank-string)
+(s/def :cimi.desc/category ::cimi-core/nonblank-string)
+(s/def :cimi.desc/description ::cimi-core/nonblank-string)
 (s/def :cimi.desc/type #{"string" "boolean" "int" "float" "timestamp" "enum" "password" "hidden" "map" "list"})
 (s/def :cimi.desc/mandatory boolean?)
 (s/def :cimi.desc/readOnly boolean?)
 (s/def :cimi.desc/order nat-int?)
-(s/def :cimi.desc/enum (s/coll-of :cimi.core/nonblank-string :min-count 1))
-(s/def :cimi.desc/instructions :cimi.core/nonblank-string)
+(s/def :cimi.desc/enum (s/coll-of ::cimi-core/nonblank-string :min-count 1))
+(s/def :cimi.desc/instructions ::cimi-core/nonblank-string)
 
 (s/def :cimi.desc/parameter-description
   (su/only-keys :req-un [:cimi.desc/type]
@@ -34,6 +35,6 @@
                          :cimi.desc/instructions]))
 
 (s/def :cimi.desc/resource-description
-  (s/every (s/or :acl (s/tuple #{:acl} :cimi.common/acl)
+  (s/every (s/or :acl (s/tuple #{:acl} ::cimi-common/acl)
                  :desc (s/tuple keyword? :cimi.desc/parameter-description))))
 

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/session.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/session.cljc
@@ -1,11 +1,10 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.session
   (:require
     [clojure.spec.alpha :as s]
-    [clojure.spec.gen.alpha :as gen]
-    [clojure.string :as str]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.session-template]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 
 ;; reference to the session template that was used to create the session
@@ -15,21 +14,21 @@
 
 ;; expiration time of the cookie
 ;; uses cookie timestamp format
-(s/def :cimi.session/expiry :cimi.core/nonblank-string)
+(s/def :cimi.session/expiry ::cimi-core/nonblank-string)
 
 ;; username is optional to support external authentication methods
 ;; that usually require creation of stub session for later validation
-(s/def :cimi.session/username :cimi.core/nonblank-string)
+(s/def :cimi.session/username ::cimi-core/nonblank-string)
 
 ;; space-separated string of user's roles
-(s/def :cimi.session/roles :cimi.core/nonblank-string)
+(s/def :cimi.session/roles ::cimi-core/nonblank-string)
 
-(s/def :cimi.session/server :cimi.core/nonblank-string)
-(s/def :cimi.session/clientIP :cimi.core/nonblank-string)
+(s/def :cimi.session/server ::cimi-core/nonblank-string)
+(s/def :cimi.session/clientIP ::cimi-core/nonblank-string)
 
 ;; supports use of the resource through browser clients,
 ;; specifically allows use of form submit buttons
-(s/def :cimi.session/redirectURI :cimi.core/nonblank-string)
+(s/def :cimi.session/redirectURI ::cimi-core/nonblank-string)
 
 (s/def :cimi/session
   (su/only-keys-maps c/common-attrs

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/session_template.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/session_template.cljc
@@ -1,23 +1,24 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.session-template
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 ;; All session resources must have a 'method' attribute.
-(s/def :cimi.session-template/method :cimi.core/identifier)
+(s/def :cimi.session-template/method ::cimi-core/identifier)
 
 ;; All session resources must have a 'instance' attribute that is used in
 ;; the template identifier.
-(s/def :cimi.session-template/instance :cimi.core/identifier)
+(s/def :cimi.session-template/instance ::cimi-core/identifier)
 
 ;; Session template resources may have a 'group' attribute that is used to group
 ;; authentication methods together.  Primarily geared towards visualization of
 ;; the authentication methods.
-(s/def :cimi.session-template/group :cimi.core/nonblank-string)
+(s/def :cimi.session-template/group ::cimi-core/nonblank-string)
 
 ;; Sessions may provide a redirect URI to be used on successful authentication.
-(s/def :cimi.session-template/redirectURI :cimi.core/nonblank-string)
+(s/def :cimi.session-template/redirectURI ::cimi-core/nonblank-string)
 
 ;; Restrict the href used to create sessions.
 (def session-template-regex #"^session-template/[a-z]+(-[a-z]+)*$")

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/session_template_api_key.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/session_template_api_key.cljc
@@ -2,10 +2,11 @@
   (:require
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.session-template :as ps]))
 
-(s/def :cimi.session-template.api-key/key :cimi.core/nonblank-string)
-(s/def :cimi.session-template.api-key/secret :cimi.core/nonblank-string)
+(s/def :cimi.session-template.api-key/key ::cimi-core/nonblank-string)
+(s/def :cimi.session-template.api-key/secret ::cimi-core/nonblank-string)
 
 ;; all parameters must be specified in both the template and the create resource
 (def session-template-keys-spec

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/session_template_internal.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/session_template_internal.cljc
@@ -2,10 +2,11 @@
   (:require
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.session-template :as ps]))
 
-(s/def :cimi.session-template.internal/username :cimi.core/nonblank-string)
-(s/def :cimi.session-template.internal/password :cimi.core/nonblank-string)
+(s/def :cimi.session-template.internal/username ::cimi-core/nonblank-string)
+(s/def :cimi.session-template.internal/password ::cimi-core/nonblank-string)
 
 ;; all parameters must be specified in both the template and the create resource
 (def session-template-keys-spec-req

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/user.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/user.cljc
@@ -1,26 +1,27 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.user
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
-(s/def :cimi.user/username :cimi.core/nonblank-string)
-(s/def :cimi.user/emailAddress :cimi.core/nonblank-string)
-(s/def :cimi.user/firstName :cimi.core/nonblank-string)
-(s/def :cimi.user/lastName :cimi.core/nonblank-string)
+(s/def :cimi.user/username ::cimi-core/nonblank-string)
+(s/def :cimi.user/emailAddress ::cimi-core/nonblank-string)
+(s/def :cimi.user/firstName ::cimi-core/nonblank-string)
+(s/def :cimi.user/lastName ::cimi-core/nonblank-string)
 (s/def :cimi.user/organization string?)
 
 (s/def :cimi.user/id (s/and string? #(re-matches #"^user/.*" %)))
 
-(s/def :cimi.user/method :cimi.core/identifier)
+(s/def :cimi.user/method ::cimi-core/identifier)
 (s/def :cimi.user/href string?)
-(s/def :cimi.user/password :cimi.core/nonblank-string)
+(s/def :cimi.user/password ::cimi-core/nonblank-string)
 (s/def :cimi.user/roles string?)
 (s/def :cimi.user/state #{"NEW" "ACTIVE" "DELETED" "SUSPENDED"})
-(s/def :cimi.user/creation :cimi.core/timestamp)
-(s/def :cimi.user/lastOnline :cimi.core/timestamp)
-(s/def :cimi.user/lastExecute :cimi.core/timestamp)
-(s/def :cimi.user/activeSince :cimi.core/timestamp)
+(s/def :cimi.user/creation ::cimi-core/timestamp)
+(s/def :cimi.user/lastOnline ::cimi-core/timestamp)
+(s/def :cimi.user/lastExecute ::cimi-core/timestamp)
+(s/def :cimi.user/activeSince ::cimi-core/timestamp)
 (s/def :cimi.user/isSuperUser boolean?)
 (s/def :cimi.user/deleted boolean?)
 (s/def :cimi.user/githublogin string?)
@@ -28,15 +29,15 @@
 
 
 (def ^:const user-common-attrs
-  {:req-un [:cimi.user/id                                   ;; less restrictive than :cimi.common/id
-            :cimi.common/resourceURI
-            :cimi.common/created
-            :cimi.common/updated
-            :cimi.common/acl]
-   :opt-un [:cimi.common/name
-            :cimi.common/description
-            :cimi.common/properties
-            :cimi.common/operations]})
+  {:req-un [:cimi.user/id              ;; less restrictive than ::cimi-common/id
+            ::cimi-common/resourceURI
+            ::cimi-common/created
+            ::cimi-common/updated
+            ::cimi-common/acl]
+   :opt-un [::cimi-common/name
+            ::cimi-common/description
+            ::cimi-common/properties
+            ::cimi-common/operations]})
 
 
 (def user-keys-spec

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/user_params_exec.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/user_params_exec.cljc
@@ -1,6 +1,2 @@
-(ns com.sixsq.slipstream.ssclj.resources.spec.user-params-exec
-  (:require
-    [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+(ns com.sixsq.slipstream.ssclj.resources.spec.user-params-exec)
 

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/user_params_template.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/user_params_template.cljc
@@ -1,10 +1,11 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.user-params-template
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
-(s/def :cimi.user-params-template/paramsType :cimi.core/nonblank-string)
+(s/def :cimi.user-params-template/paramsType ::cimi-core/nonblank-string)
 
 (def user-params-template-keys-spec
   {:req-un [:cimi.user-params-template/paramsType]})
@@ -13,14 +14,14 @@
   {:opt-un [:cimi.user-params-template/paramsType]})
 
 (def resource-keys-spec
-  (su/merge-keys-specs [c/common-attrs
+  (su/merge-keys-specs [cimi-common/common-attrs
                         user-params-template-keys-spec]))
 
 (def create-keys-spec
-  (su/merge-keys-specs [c/create-attrs]))
+  (su/merge-keys-specs [cimi-common/create-attrs]))
 
 ;; subclasses MUST provide the href to the template to use
 (def template-keys-spec
-  (su/merge-keys-specs [c/template-attrs
+  (su/merge-keys-specs [cimi-common/template-attrs
                         user-params-template-keys-spec-opt]))
 

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/user_params_template_exec.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/user_params_template_exec.cljc
@@ -2,13 +2,13 @@
   (:require
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.user-params-template :as ps]))
 
 (s/def :cimi.user-params-template-exec/defaultCloudService string?)
 (s/def :cimi.user-params-template-exec/sshPublicKey string?)
-(s/def :cimi.user-params-template-exec/keepRunning :cimi.core/nonblank-string)
-(s/def :cimi.user-params-template-exec/mailUsage :cimi.core/nonblank-string)
+(s/def :cimi.user-params-template-exec/keepRunning ::cimi-core/nonblank-string)
+(s/def :cimi.user-params-template-exec/mailUsage ::cimi-core/nonblank-string)
 (s/def :cimi.user-params-template-exec/verbosityLevel int?)
 (s/def :cimi.user-params-template-exec/timeout int?)
 

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/user_template.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/user_template.cljc
@@ -1,13 +1,13 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.user-template
   (:require
     [clojure.spec.alpha :as s]
-    [clojure.spec.gen.alpha :as gen]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.user :as us]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]))
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.resources.spec.user :as user-spec]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 ;; All user templates must indicate the method used to create the user.
-(s/def :cimi.user-template/method :cimi.core/identifier)
+(s/def :cimi.user-template/method ::cimi-core/identifier)
 
 (def user-template-regex #"^user-template/[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$")
 (s/def :cimi.user-template/href (s/and string? #(re-matches user-template-regex %)))

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/user_template_direct.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/user_template_direct.cljc
@@ -1,18 +1,19 @@
 (ns com.sixsq.slipstream.ssclj.resources.spec.user-template-direct
   (:require
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
     [com.sixsq.slipstream.ssclj.resources.spec.user :as u]
-    [com.sixsq.slipstream.ssclj.resources.spec.user-template :as ps]))
+    [com.sixsq.slipstream.ssclj.resources.spec.user-template :as ps]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 (s/def :cimi.user-template.direct/href :cimi.user-template/href)
-(s/def :cimi.user-template.direct/password :cimi.core/nonblank-string)
+(s/def :cimi.user-template.direct/password ::cimi-core/nonblank-string)
 (s/def :cimi.user-template.direct/roles string?)
-(s/def :cimi.user-template.direct/state :cimi.core/nonblank-string)
-(s/def :cimi.user-template.direct/creation :cimi.core/timestamp)
-(s/def :cimi.user-template.direct/lastOnline :cimi.core/timestamp)
-(s/def :cimi.user-template.direct/lastExecute :cimi.core/timestamp)
-(s/def :cimi.user-template.direct/activeSince :cimi.core/timestamp)
+(s/def :cimi.user-template.direct/state ::cimi-core/nonblank-string)
+(s/def :cimi.user-template.direct/creation ::cimi-core/timestamp)
+(s/def :cimi.user-template.direct/lastOnline ::cimi-core/timestamp)
+(s/def :cimi.user-template.direct/lastExecute ::cimi-core/timestamp)
+(s/def :cimi.user-template.direct/activeSince ::cimi-core/timestamp)
 (s/def :cimi.user-template.direct/isSuperUser boolean?)
 (s/def :cimi.user-template.direct/deleted boolean?)
 (s/def :cimi.user-template.direct/githublogin string?)

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/spec/common_test.cljc
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/spec/common_test.cljc
@@ -2,11 +2,13 @@
   (:require
     [clojure.test :refer [deftest are is]]
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]
-    [com.sixsq.slipstream.ssclj.resources.spec.common :as t]))
+    [com.sixsq.slipstream.ssclj.resources.spec.acl :as cimi-acl]
+    [com.sixsq.slipstream.ssclj.resources.spec.common :as cimi-common]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 (deftest check-nonblank-string
-  (are [expect-fn arg] (expect-fn (s/valid? :cimi.core/nonblank-string arg))
+  (are [expect-fn arg] (expect-fn (s/valid? ::cimi-core/nonblank-string arg))
                        true? "ok"
                        true? " ok"
                        true? "ok "
@@ -18,12 +20,12 @@
                        false? "\t\f"))
 
 (deftest check-timestamp
-  (are [expect-fn arg] (expect-fn (s/valid? :cimi.core/timestamp arg))
+  (are [expect-fn arg] (expect-fn (s/valid? ::cimi-core/timestamp arg))
                        true? "2012-01-01T01:23:45.678Z"
                        false? "2012-01-01T01:23:45.678Q"))
 
 (deftest check-resource-link
-  (are [expect-fn arg] (expect-fn (s/valid? :cimi.common/resource-link arg))
+  (are [expect-fn arg] (expect-fn (s/valid? ::cimi-common/resource-link arg))
                        true? {:href "uri"}
                        false? {}
                        false? {:bad "value"}
@@ -31,26 +33,26 @@
                        true? {:href "uri" :ok "value"}))
 
 (deftest check-resource-links
-  (are [expect-fn arg] (expect-fn (s/valid? :cimi.common/resource-links arg))
+  (are [expect-fn arg] (expect-fn (s/valid? ::cimi-common/resource-links arg))
                        true? [{:href "uri"}]
                        true? [{:href "uri"} {:href "uri"}]
                        false? []))
 
 (deftest check-operation
-  (are [expect-fn arg] (expect-fn (s/valid? :cimi.common/operation arg))
+  (are [expect-fn arg] (expect-fn (s/valid? ::cimi-common/operation arg))
                        true? {:href "uri" :rel "add"}
                        false? {:href "uri"}
                        false? {:rel "add"}
                        false? {}))
 
 (deftest check-operations
-  (are [expect-fn arg] (expect-fn (s/valid? :cimi.common/operations arg))
+  (are [expect-fn arg] (expect-fn (s/valid? ::cimi-common/operations arg))
                        true? [{:href "uri" :rel "add"}]
                        true? [{:href "uri" :rel "add"} {:href "uri" :rel "delete"}]
                        false? []))
 
 (deftest check-properties
-  (are [expect-fn arg] (expect-fn (s/valid? :cimi.common/properties arg))
+  (are [expect-fn arg] (expect-fn (s/valid? ::cimi-common/properties arg))
                        true? {:a "ok"}
                        true? {:a "ok" :b "ok"}
                        true? {"a" "ok"}
@@ -62,7 +64,7 @@
 
 (deftest check-owner
   (let [id {:principal "ADMIN", :type "ROLE"}]
-    (are [expect-fn arg] (expect-fn (s/valid? :cimi.acl/owner arg))
+    (are [expect-fn arg] (expect-fn (s/valid? ::cimi-acl/owner arg))
                          true? id
                          false? (assoc id :bad "MODIFY")
                          false? (dissoc id :principal)
@@ -71,7 +73,7 @@
 
 (deftest check-rule
   (let [rule {:principal "ADMIN", :type "ROLE", :right "VIEW"}]
-    (are [expect-fn arg] (expect-fn (s/valid? :cimi.acl/rule arg))
+    (are [expect-fn arg] (expect-fn (s/valid? ::cimi-acl/rule arg))
                          true? rule
                          true? (assoc rule :right "MODIFY")
                          true? (assoc rule :right "ALL")
@@ -81,7 +83,7 @@
 (deftest check-rules
   (let [rules [{:principal "ADMIN", :type "ROLE", :right "VIEW"}
                {:principal "ALPHA", :type "USER", :right "ALL"}]]
-    (are [expect-fn arg] (expect-fn (s/valid? :cimi.acl/rules arg))
+    (are [expect-fn arg] (expect-fn (s/valid? ::cimi-acl/rules arg))
                          true? rules
                          true? (next rules)
                          false? (nnext rules)
@@ -96,14 +98,14 @@
                      {:principal "group2"
                       :type      "ROLE"
                       :right     "MODIFY"}]}]
-    (are [expect-fn arg] (expect-fn (s/valid? :cimi.common/acl arg))
+    (are [expect-fn arg] (expect-fn (s/valid? ::cimi-common/acl arg))
                          true? acl
                          true? (dissoc acl :rules)
                          false? (assoc acl :rules [])
                          false? (assoc acl :owner "")
                          false? (assoc acl :bad "BAD"))))
 
-(s/def :cimi.test/common-attrs (su/only-keys-maps t/common-attrs))
+(s/def ::common-attrs (su/only-keys-maps cimi-common/common-attrs))
 
 (deftest check-common-attrs
   (let [date "2012-01-01T01:23:45.678Z"
@@ -126,7 +128,7 @@
                   :properties {"a" "b"}
                   :operations [{:rel "add" :href "/add"}]
                   :acl acl)]
-    (are [expect-fn arg] (expect-fn (s/valid? :cimi.test/common-attrs arg))
+    (are [expect-fn arg] (expect-fn (s/valid? ::common-attrs arg))
                          true? minimal
                          false? (dissoc minimal :id)
                          false? (dissoc minimal :resourceURI)

--- a/dummy-connector/config/src/com/sixsq/slipstream/connector/dummy_template.clj
+++ b/dummy-connector/config/src/com/sixsq/slipstream/connector/dummy_template.clj
@@ -2,11 +2,11 @@
   (:require
     [clojure.set :as set]
     [clojure.spec.alpha :as s]
-    [com.sixsq.slipstream.ssclj.resources.common.schema :as sch]
     [com.sixsq.slipstream.ssclj.resources.common.utils :as u]
     [com.sixsq.slipstream.ssclj.resources.connector-template :as ctpl]
-    [com.sixsq.slipstream.ssclj.util.config :as uc]
     [com.sixsq.slipstream.ssclj.resources.spec.connector-template :as ps]
+    [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
+    [com.sixsq.slipstream.ssclj.util.config :as uc]
     [com.sixsq.slipstream.ssclj.util.spec :as su]))
 
 (def ^:const cloud-service-type "dummy")
@@ -21,9 +21,9 @@
 ;;
 ;; schemas
 ;;
-(s/def :cimi.connector-template.dummy/orchestratorInstanceType :cimi.core/nonblank-string)
-(s/def :cimi.connector-template.dummy/zone :cimi.core/nonblank-string)
-(s/def :cimi.connector-template.dummy/orchestratorDisk :cimi.core/nonblank-string)
+(s/def :cimi.connector-template.dummy/orchestratorInstanceType ::cimi-core/nonblank-string)
+(s/def :cimi.connector-template.dummy/zone ::cimi-core/nonblank-string)
+(s/def :cimi.connector-template.dummy/orchestratorDisk ::cimi-core/nonblank-string)
 (s/def :cimi.connector-template.dummy/objectStoreEndpoint :cimi.connector-template/objectStoreEndpoint)
 
 (def keys-spec {:req-un [:cimi.connector-template/endpoint


### PR DESCRIPTION
This is WIP.

First step done
- split cimi common spec ns into common, core, acl, common-operation ns-es. @loomis Please comment on this.  Thanks.

Connected to #1473 