### PR TITLE
allow default ordering for events to be overridden

### DIFF
--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/event.clj
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/event.clj
@@ -71,5 +71,5 @@
 ;;
 (def query-impl (std-crud/query-fn resource-name collection-acl collection-uri resource-tag))
 (defmethod crud/query resource-name
-  [request]
-  (query-impl (update-in request [:cimi-params] #(assoc % :orderby [["timestamp" :desc]]))))
+  [{{:keys [orderby]} :cimi-params :as request}]
+  (query-impl (assoc-in request [:cimi-params :orderby] (if (seq orderby) orderby [["timestamp" :desc]]))))

--- a/cimi-resources/test/com/sixsq/slipstream/ssclj/resources/event/test_utils.clj
+++ b/cimi-resources/test/com/sixsq/slipstream/ssclj/resources/event/test_utils.clj
@@ -85,3 +85,11 @@
   (every? (fn [[a b]] (not-before? (to-time a) (to-time b))) (partition 2 1 timestamps)))
 
 
+(def not-after? (complement time/after?))
+
+
+(defn ordered-asc?
+  [timestamps]
+  (every? (fn [[a b]] (not-after? (to-time a) (to-time b))) (partition 2 1 timestamps)))
+
+

--- a/cimi-resources/test/com/sixsq/slipstream/ssclj/resources/event_test.clj
+++ b/cimi-resources/test/com/sixsq/slipstream/ssclj/resources/event_test.clj
@@ -69,6 +69,12 @@
        tu/ordered-desc?
        is))
 
+(deftest check-events-can-be-reordered
+  (->> (get-in (exec-request base-uri "?$orderby=timestamp:asc" "joe") [:response :body :events])
+       (map :timestamp)
+       tu/ordered-asc?
+       is))
+
 (defn timestamp-paginate-single
   [n]
   (-> (exec-request base-uri (str "?$first=" n "&$last=" n) "joe")
@@ -84,7 +90,7 @@
 
 (deftest resources-pagination
   (are-counts nb-events "")
-  ;; two differents count are checked
+  ;; two different counts are checked
   ;; first one should be not impacted by pagination (so we expect nb-events)
   ;; second is the count after pagination (0 in that case with a bogus pagination)
   (are-counts nb-events 0 "?$first=10&$last=5")


### PR DESCRIPTION
Events were always returned in descending order based on their timestamps.  However, there are times when other orderings are desired.  This change will only apply the default if no `$orderby` value has been provided.  If a value for `$orderby` is provided, the default is ignored.
