### PR TITLE
Task/remove base url for oidc configs

### DIFF
--- a/cimi/src/com/sixsq/slipstream/auth/oidc.clj
+++ b/cimi/src/com/sixsq/slipstream/auth/oidc.clj
@@ -5,8 +5,8 @@
 
 
 (defn get-access-token
-  [client-id client-secret base-url tokenURL oidc-code redirect-uri]
-  (-> (http/post (or tokenURL (str base-url "/token"))
+  [client-id client-secret tokenURL oidc-code redirect-uri]
+  (-> (http/post tokenURL
                  {:headers     {"Accept" "application/json"}
                   :form-params {:grant_type    "authorization_code"
                                 :code          oidc-code

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_create_session_mitreid.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_create_session_mitreid.clj
@@ -26,9 +26,9 @@
 
   (let [{:keys [server clientIP redirectURI] {:keys [href]} :sessionTemplate :as current-session} (sutils/retrieve-session-by-id session-id)
         instance (u/document-id href)
-        [client-id client-secret base-url public-key authorizeURL tokenURL userInfoURL] (oidc-utils/config-mitreid-params redirectURI instance)]
+        [client-id client-secret  public-key authorizeURL tokenURL userInfoURL] (oidc-utils/config-mitreid-params redirectURI instance)]
     (if-let [code (uh/param-value request :code)]
-      (if-let [access-token (auth-oidc/get-access-token client-id client-secret base-url tokenURL code (str base-uri (or callback-id "unknown-id") "/execute"))]
+      (if-let [access-token (auth-oidc/get-access-token client-id client-secret tokenURL code (str base-uri (or callback-id "unknown-id") "/execute"))]
         (try
           (let [{:keys [sub] :as claims} (sign/unsign-claims access-token public-key)
                 roles (concat (oidc-utils/extract-roles claims)

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_create_session_mitreid.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_create_session_mitreid.clj
@@ -26,7 +26,7 @@
 
   (let [{:keys [server clientIP redirectURI] {:keys [href]} :sessionTemplate :as current-session} (sutils/retrieve-session-by-id session-id)
         instance (u/document-id href)
-        [client-id client-secret  public-key authorizeURL tokenURL userInfoURL] (oidc-utils/config-mitreid-params redirectURI instance)]
+        [client-id client-secret public-key authorizeURL tokenURL userProfileURL] (oidc-utils/config-mitreid-params redirectURI instance)]
     (if-let [code (uh/param-value request :code)]
       (if-let [access-token (auth-oidc/get-access-token client-id client-secret tokenURL code (str base-uri (or callback-id "unknown-id") "/execute"))]
         (try
@@ -34,7 +34,7 @@
                 roles (concat (oidc-utils/extract-roles claims)
                               (oidc-utils/extract-groups claims)
                               (oidc-utils/extract-entitlements claims))
-                {:keys [username] :as userinfo} (when sub (oidc-utils/get-mitreid-userinfo userInfoURL access-token))]
+                {:keys [username] :as userinfo} (when sub (oidc-utils/get-mitreid-userinfo userProfileURL access-token))]
             (log/debug "MITREid access token claims for" instance ":" (pr-str claims))
             (if sub
               (if-let [matched-user (ex/match-oidc-username username instance)]

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_create_session_oidc.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_create_session_oidc.clj
@@ -26,9 +26,9 @@
 
   (let [{:keys [server clientIP redirectURI] {:keys [href]} :sessionTemplate :as current-session} (sutils/retrieve-session-by-id session-id)
         instance (u/document-id href)
-        [client-id client-secret base-url public-key authorizeURL tokenURL] (oidc-utils/config-oidc-params redirectURI instance)]
+        [client-id client-secret public-key authorizeURL tokenURL] (oidc-utils/config-oidc-params redirectURI instance)]
     (if-let [code (uh/param-value request :code)]
-      (if-let [access-token (auth-oidc/get-access-token client-id client-secret base-url tokenURL code (str base-uri (or callback-id "unknown-id") "/execute"))]
+      (if-let [access-token (auth-oidc/get-access-token client-id client-secret tokenURL code (str base-uri (or callback-id "unknown-id") "/execute"))]
         (try
           (let [{:keys [sub] :as claims} (sign/unsign-claims access-token public-key)
                 roles (concat (oidc-utils/extract-roles claims)

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_create_user_mitreid.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_create_user_mitreid.clj
@@ -19,12 +19,12 @@
 (defn register-user
   [{{href :href} :targetResource {:keys [redirectURI]} :data callback-id :id :as callback-resource} {:keys [headers base-uri uri] :as request}]
   (let [instance (u/document-id href)
-        [client-id client-secret public-key authorizeURL tokenURL userInfoURL] (oidc-utils/config-mitreid-params redirectURI instance)]
+        [client-id client-secret public-key authorizeURL tokenURL userProfileURL] (oidc-utils/config-mitreid-params redirectURI instance)]
     (if-let [code (uh/param-value request :code)]
       (if-let [access-token (auth-oidc/get-access-token client-id client-secret tokenURL code (str base-uri (or callback-id "unknown-id") "/execute"))]
         (try
           (let [{:keys [sub] :as claims} (sign/unsign-claims access-token public-key)
-                {:keys [username givenName familyName emails] :as userinfo} (when sub (oidc-utils/get-mitreid-userinfo userInfoURL access-token))
+                {:keys [username givenName familyName emails] :as userinfo} (when sub (oidc-utils/get-mitreid-userinfo userProfileURL access-token))
                 email (-> (filter :primary emails)
                           first
                           :value)]

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_create_user_mitreid.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_create_user_mitreid.clj
@@ -19,9 +19,9 @@
 (defn register-user
   [{{href :href} :targetResource {:keys [redirectURI]} :data callback-id :id :as callback-resource} {:keys [headers base-uri uri] :as request}]
   (let [instance (u/document-id href)
-        [client-id client-secret base-url public-key authorizeURL tokenURL userInfoURL] (oidc-utils/config-mitreid-params redirectURI instance)]
+        [client-id client-secret public-key authorizeURL tokenURL userInfoURL] (oidc-utils/config-mitreid-params redirectURI instance)]
     (if-let [code (uh/param-value request :code)]
-      (if-let [access-token (auth-oidc/get-access-token client-id client-secret base-url tokenURL code (str base-uri (or callback-id "unknown-id") "/execute"))]
+      (if-let [access-token (auth-oidc/get-access-token client-id client-secret tokenURL code (str base-uri (or callback-id "unknown-id") "/execute"))]
         (try
           (let [{:keys [sub] :as claims} (sign/unsign-claims access-token public-key)
                 {:keys [username givenName familyName emails] :as userinfo} (when sub (oidc-utils/get-mitreid-userinfo userInfoURL access-token))

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_create_user_oidc.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_create_user_oidc.clj
@@ -19,9 +19,9 @@
 (defn register-user
   [{{href :href} :targetResource {:keys [redirectURI]} :data callback-id :id :as callback-resource} {:keys [headers base-uri uri] :as request}]
   (let [instance (u/document-id href)
-        [client-id client-secret base-url public-key authorizeURL tokenURL] (oidc-utils/config-oidc-params redirectURI instance)]
+        [client-id client-secret public-key authorizeURL tokenURL] (oidc-utils/config-oidc-params redirectURI instance)]
     (if-let [code (uh/param-value request :code)]
-      (if-let [access-token (auth-oidc/get-access-token client-id client-secret base-url tokenURL code (str base-uri (or callback-id "unknown-id") "/execute"))]
+      (if-let [access-token (auth-oidc/get-access-token client-id client-secret tokenURL code (str base-uri (or callback-id "unknown-id") "/execute"))]
         (try
           (let [{:keys [sub email given_name family_name realm] :as claims} (sign/unsign-claims access-token public-key)]
             (log/debugf "oidc access token claims for %s: %s" instance (pr-str claims))

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/configuration_template_session_mitreid.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/configuration_template_session_mitreid.clj
@@ -10,16 +10,16 @@
 ;; resource
 ;;
 (def ^:const resource
-  {:service     service
-   :name        "MITREid Authentication Configuration"
-   :description "MITREid OpenID Connect Authentication Configuration"
-   :instance    "authn-name"
-   :authorizeURL "http://auth.example.com"
-   :tokenURL    "http://token.example.com"
-   :userInfoURL "http://userinfo.example.com"
-   :clientID    "server-assigned-client-id"
-   :clientSecret "aaabbbcccdddd"
-   :publicKey   "ABCDEF..."})
+  {:service        service
+   :name           "MITREid Authentication Configuration"
+   :description    "MITREid OpenID Connect Authentication Configuration"
+   :instance       "authn-name"
+   :authorizeURL   "http://auth.example.com"
+   :tokenURL       "http://token.example.com"
+   :userProfileURL "http://userinfo.example.com"
+   :clientID       "server-assigned-client-id"
+   :clientSecret   "aaabbbcccdddd"
+   :publicKey      "ABCDEF..."})
 
 
 ;;
@@ -27,42 +27,42 @@
 ;;
 (def ^:const desc
   (merge p/ConfigurationTemplateDescription
-         {:clientID     {:displayName "Client ID"
+         {:clientID       {:displayName "Client ID"
                          :type        "string"
                          :description "client identifier assigned by the MITREid server"
                          :mandatory   true
                          :readOnly    false
                          :order       20}
-          :clientSecret {:displayName "Client Secret"
+          :clientSecret   {:displayName "Client Secret"
                          :type        "password"
                          :description "client secret assigned by the MITREid server"
                          :mandatory   true
                          :readOnly    false
                          :order       21}
-          :publicKey    {:displayName "Public Key"
+          :publicKey      {:displayName "Public Key"
                          :type        "string"
                          :description "public key to verify signed tokens from the MITREid server"
                          :mandatory   true
                          :readOnly    false
                          :order       22}
-          :authorizeURL {:displayName "Authorize URL"
+          :authorizeURL   {:displayName "Authorize URL"
                          :type        "string"
                          :description "server's endpoint authentication URL for the MITREid protocol"
                          :mandatory   true
                          :readOnly    false
                          :order       23}
-          :tokenURL     {:displayName "Token URL"
+          :tokenURL       {:displayName "Token URL"
                          :type        "string"
                          :description "server's endpoint token URL for the MITREid protocol"
                          :mandatory   true
                          :readOnly    false
                          :order       24}
-          :userInfoURL  {:displayName "User information URL"
-                         :type        "string"
-                         :description "server's endpoint user info URL for the MITREid protocol"
-                         :mandatory   true
-                         :readOnly    false
-                         :order       25}}))
+          :userProfileURL {:displayName "User information URL"
+                         :type          "string"
+                         :description   "server's endpoint user info URL for the MITREid protocol"
+                         :mandatory     true
+                         :readOnly      false
+                         :order         25}}))
 
 ;;
 ;; initialization: register this Configuration template

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/configuration_template_session_mitreid.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/configuration_template_session_mitreid.clj
@@ -14,7 +14,11 @@
    :name        "MITREid Authentication Configuration"
    :description "MITREid OpenID Connect Authentication Configuration"
    :instance    "authn-name"
+   :authorizeURL "http://auth.example.com"
+   :tokenURL    "http://token.example.com"
+   :userInfoURL "http://userinfo.example.com"
    :clientID    "server-assigned-client-id"
+   :clientSecret "aaabbbcccdddd"
    :publicKey   "ABCDEF..."})
 
 
@@ -32,31 +36,31 @@
           :clientSecret {:displayName "Client Secret"
                          :type        "password"
                          :description "client secret assigned by the MITREid server"
-                         :mandatory   false
+                         :mandatory   true
                          :readOnly    false
                          :order       21}
-          :userInfoURL  {:displayName "User information URL"
-                         :type        "string"
-                         :description "server's endpoint user info URL for the MITREid protocol"
-                         :mandatory   false
-                         :readOnly    false
-                         :order       22}
           :publicKey    {:displayName "Public Key"
                          :type        "string"
                          :description "public key to verify signed tokens from the MITREid server"
                          :mandatory   true
                          :readOnly    false
-                         :order       23}
+                         :order       22}
           :authorizeURL {:displayName "Authorize URL"
                          :type        "string"
                          :description "server's endpoint authentication URL for the MITREid protocol"
-                         :mandatory   false
+                         :mandatory   true
                          :readOnly    false
-                         :order       24}
+                         :order       23}
           :tokenURL     {:displayName "Token URL"
                          :type        "string"
                          :description "server's endpoint token URL for the MITREid protocol"
-                         :mandatory   false
+                         :mandatory   true
+                         :readOnly    false
+                         :order       24}
+          :userInfoURL  {:displayName "User information URL"
+                         :type        "string"
+                         :description "server's endpoint user info URL for the MITREid protocol"
+                         :mandatory   true
                          :readOnly    false
                          :order       25}}))
 

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/configuration_template_session_oidc.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/configuration_template_session_oidc.clj
@@ -14,6 +14,8 @@
    :name        "OIDC Authentication Configuration"
    :description "OpenID Connect Authentication Configuration"
    :instance    "authn-name"
+   :authorizeURL "http://auth.example.com"
+   :tokenURL    "http://token.example.com"
    :clientID    "server-assigned-client-id"
    :publicKey   "ABCDEF..."})
 
@@ -35,30 +37,24 @@
                          :mandatory   false
                          :readOnly    false
                          :order       21}
-          :baseURL      {:displayName "Base URL"
-                         :type        "string"
-                         :description "server's endpoint URL for the OIDC protocol"
-                         :mandatory   false
-                         :readOnly    false
-                         :order       22}
           :publicKey    {:displayName "Public Key"
                          :type        "string"
                          :description "public key to verify signed tokens from the OIDC server"
                          :mandatory   true
                          :readOnly    false
-                         :order       23}
+                         :order       22}
           :authorizeURL {:displayName "Authorize URL"
                          :type        "string"
                          :description "server's endpoint authentication URL for the OIDC protocol"
-                         :mandatory   false
+                         :mandatory   true
                          :readOnly    false
-                         :order       24}
+                         :order       23}
           :tokenURL     {:displayName "Token URL"
                          :type        "string"
                          :description "server's endpoint token URL for the OIDC protocol"
-                         :mandatory   false
+                         :mandatory   true
                          :readOnly    false
-                         :order       25}}))
+                         :order       24}}))
 
 ;;
 ;; initialization: register this Configuration template

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/session_mitreid.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/session_mitreid.clj
@@ -48,7 +48,7 @@
 ;;
 (defmethod p/tpl->session authn-method
   [{:keys [href redirectURI] :as resource} {:keys [headers base-uri] :as request}]
-  (let [[client-id client-secret public-key authorizeURL tokenURL userInfoURL] (oidc-utils/config-mitreid-params redirectURI (u/document-id href))
+  (let [[client-id client-secret public-key authorizeURL tokenURL userProfileURL] (oidc-utils/config-mitreid-params redirectURI (u/document-id href))
         session-init (cond-> {:href href}
                              redirectURI (assoc :redirectURI redirectURI))
         session (sutils/create-session session-init headers authn-method)

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/session_mitreid.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/session_mitreid.clj
@@ -48,8 +48,7 @@
 ;;
 (defmethod p/tpl->session authn-method
   [{:keys [href redirectURI] :as resource} {:keys [headers base-uri] :as request}]
-  (let [[client-id client-secret public-key authorizeURL tokenURL userInfoURL]
-        (oidc-utils/config-mitreid-params redirectURI (u/document-id href))
+  (let [[client-id client-secret public-key authorizeURL tokenURL userInfoURL] (oidc-utils/config-mitreid-params redirectURI (u/document-id href))
         session-init (cond-> {:href href}
                              redirectURI (assoc :redirectURI redirectURI))
         session (sutils/create-session session-init headers authn-method)

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/session_oidc.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/session_oidc.clj
@@ -49,16 +49,14 @@
 ;;
 (defmethod p/tpl->session authn-method
   [{:keys [href redirectURI] :as resource} {:keys [headers base-uri] :as request}]
-  (let [[client-id client-secret base-url public-key authorizeURL tokenURL] (oidc-utils/config-oidc-params redirectURI (u/document-id href))]
-    (if (or (and base-url client-id public-key) (and authorizeURL tokenURL client-id client-secret public-key))
-      (let [session-init (cond-> {:href href}
-                                 redirectURI (assoc :redirectURI redirectURI))
-            session (sutils/create-session session-init headers authn-method)
-            session (assoc session :expiry (ts/rfc822->iso8601 (ts/expiry-later-rfc822 login-request-timeout)))
-            callback-url (oidc-utils/create-callback base-uri (:id session) cb/action-name)
-            redirect-url (oidc-utils/create-redirect-url base-url authorizeURL client-id callback-url)]
-        [{:status 303, :headers {"Location" redirect-url}} session])
-      (oidc-utils/throw-bad-client-config authn-method redirectURI))))
+  (let [[client-id client-secret  public-key authorizeURL tokenURL] (oidc-utils/config-oidc-params redirectURI (u/document-id href))
+        session-init (cond-> {:href href}
+                             redirectURI (assoc :redirectURI redirectURI))
+        session (sutils/create-session session-init headers authn-method)
+        session (assoc session :expiry (ts/rfc822->iso8601 (ts/expiry-later-rfc822 login-request-timeout)))
+        callback-url (oidc-utils/create-callback base-uri (:id session) cb/action-name)
+        redirect-url (oidc-utils/create-redirect-url authorizeURL client-id callback-url)]
+        [{:status 303, :headers {"Location" redirect-url}} session]))
 
 ;;
 ;; initialization: no schema for this parent resource

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/session_oidc/utils.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/session_oidc/utils.clj
@@ -86,8 +86,8 @@
 
 
 (defn valid-mitreid-config?
-  [{:keys [clientID clientSecret publicKey authorizeURL tokenURL userInfoURL] :as config}]
-  (and clientID clientSecret authorizeURL tokenURL userInfoURL publicKey))
+  [{:keys [clientID clientSecret publicKey authorizeURL tokenURL userProfileURL] :as config}]
+  (and clientID clientSecret authorizeURL tokenURL userProfileURL publicKey))
 
 (defn valid-oidc-config?
   "An OIDC config without clientSecret is valid (e.g KeyCloak)"
@@ -113,9 +113,9 @@
   (let [cfg-id (str "configuration/session-mitreid-" instance)]
     (try
       (let [mitreid-config (crud/retrieve-by-id-as-admin cfg-id)
-            {:keys [clientID clientSecret publicKey authorizeURL tokenURL userInfoURL]} mitreid-config]
+            {:keys [clientID clientSecret publicKey authorizeURL tokenURL userProfileURL]} mitreid-config]
         (if (valid-mitreid-config? mitreid-config)
-          [clientID clientSecret publicKey authorizeURL tokenURL userInfoURL]
+          [clientID clientSecret publicKey authorizeURL tokenURL userProfileURL]
           (throw-bad-client-config cfg-id redirectURI)))
       (catch Exception _
         (throw-bad-client-config cfg-id redirectURI)))))
@@ -147,8 +147,8 @@
     (str authorizeURL (format url-params-format client-id callback-url))))
 
 (defn get-mitreid-userinfo
-  [userInfoURL access_token]
-  (-> (http/get userInfoURL
+  [userProfileURL access_token]
+  (-> (http/get userProfileURL
                 {:headers      {"Accept" "application/json"}
                  :query-params {::access_token access_token}})
       :body

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/session_oidc/utils.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/session_oidc/utils.clj
@@ -83,15 +83,27 @@
 (defn throw-user-exists [username redirectURI]
   (logu/log-error-and-throw-with-redirect 400 (str "account already exists (" username ")") redirectURI))
 
+
+
+(defn valid-mitreid-config?
+  [{:keys [clientID clientSecret publicKey authorizeURL tokenURL userInfoURL] :as config}]
+  (and clientID clientSecret authorizeURL tokenURL userInfoURL publicKey))
+
+(defn valid-oidc-config?
+  "An OIDC config without clientSecret is valid (e.g KeyCloak)"
+  [{:keys [clientID publicKey authorizeURL tokenURL] :as config}]
+  (and clientID authorizeURL tokenURL publicKey))
+
 ;; retrieval of configuration parameters
 
 (defn config-oidc-params
   [redirectURI instance]
   (let [cfg-id (str "configuration/session-oidc-" instance)]
     (try
-      (let [{:keys [clientID clientSecret baseURL publicKey authorizeURL tokenURL]} (crud/retrieve-by-id-as-admin cfg-id)]
-        (if (or (and clientID baseURL publicKey) (and clientID clientSecret authorizeURL tokenURL publicKey))
-          [clientID clientSecret baseURL publicKey authorizeURL tokenURL]
+      (let [oidc-config (crud/retrieve-by-id-as-admin cfg-id)
+            {:keys [clientID clientSecret publicKey authorizeURL tokenURL]} oidc-config]
+        (if (valid-oidc-config? oidc-config)
+          [clientID clientSecret publicKey authorizeURL tokenURL]
           (throw-bad-client-config cfg-id redirectURI)))
       (catch Exception _
         (throw-bad-client-config cfg-id redirectURI)))))
@@ -100,9 +112,10 @@
   [redirectURI instance]
   (let [cfg-id (str "configuration/session-mitreid-" instance)]
     (try
-      (let [{:keys [clientID clientSecret baseURL publicKey authorizeURL tokenURL userInfoURL]} (crud/retrieve-by-id-as-admin cfg-id)]
-        (if (and clientID clientSecret authorizeURL tokenURL userInfoURL publicKey)
-          [clientID clientSecret baseURL publicKey authorizeURL tokenURL userInfoURL]
+      (let [mitreid-config (crud/retrieve-by-id-as-admin cfg-id)
+            {:keys [clientID clientSecret publicKey authorizeURL tokenURL userInfoURL]} mitreid-config]
+        (if (valid-mitreid-config? mitreid-config)
+          [clientID clientSecret publicKey authorizeURL tokenURL userInfoURL]
           (throw-bad-client-config cfg-id redirectURI)))
       (catch Exception _
         (throw-bad-client-config cfg-id redirectURI)))))
@@ -128,12 +141,10 @@
         (throw (ex-info msg (r/map-response msg 500 session-id)))))))
 
 (defn create-redirect-url
-  "Generate a callback-url. By default, use authorizeURL if provided,
-  otherwise fallback to base-url/auth"
-  [base-url authorizeURL client-id callback-url]
-  (let [url-params-format "?response_type=code&client_id=%s&redirect_uri=%s"
-        base-redirect-url (or authorizeURL (str base-url "/auth"))]
-    (str base-redirect-url (format url-params-format client-id callback-url))))
+  "Generate a redirect-url from the provided authorizeURL"
+  [authorizeURL client-id callback-url]
+  (let [url-params-format "?response_type=code&client_id=%s&redirect_uri=%s"]
+    (str authorizeURL (format url-params-format client-id callback-url))))
 
 (defn get-mitreid-userinfo
   [userInfoURL access_token]

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template_session_mitreid.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template_session_mitreid.cljc
@@ -14,12 +14,10 @@
 (s/def ::publicKey ::cimi-core/nonblank-string)             ;; allows jwk JSON representation
 
 (def configuration-template-keys-spec-req
-  {:req-un [::ps/instance ::clientID  ::publicKey]
-   :opt-un [::baseURL ::authorizeURL ::tokenURL ::userInfoURL ::clientSecret]})
+  {:req-un [::ps/instance ::clientID  ::clientSecret ::publicKey ::authorizeURL ::tokenURL ::userInfoURL]})
 
 (def configuration-template-keys-spec-create
-  {:req-un [::ps/instance ::clientID ::publicKey]
-   :opt-un [::baseURL ::authorizeURL ::tokenURL ::userInfoURL ::clientSecret]})
+  {:req-un [::ps/instance ::clientID ::clientSecret ::publicKey ::authorizeURL ::tokenURL ::userInfoURL]})
 
 ;; Defines the contents of the Mi authentication ConfigurationTemplate resource itself.
 (s/def ::session-mitreid

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template_session_mitreid.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template_session_mitreid.cljc
@@ -10,14 +10,14 @@
 (s/def ::baseURL ::cimi-core/token)
 (s/def ::authorizeURL ::cimi-core/token)
 (s/def ::tokenURL ::cimi-core/token)
-(s/def ::userInfoURL ::cimi-core/token)
+(s/def ::userProfileURL ::cimi-core/token)
 (s/def ::publicKey ::cimi-core/nonblank-string)             ;; allows jwk JSON representation
 
 (def configuration-template-keys-spec-req
-  {:req-un [::ps/instance ::clientID  ::clientSecret ::publicKey ::authorizeURL ::tokenURL ::userInfoURL]})
+  {:req-un [::ps/instance ::clientID  ::clientSecret ::publicKey ::authorizeURL ::tokenURL ::userProfileURL]})
 
 (def configuration-template-keys-spec-create
-  {:req-un [::ps/instance ::clientID ::clientSecret ::publicKey ::authorizeURL ::tokenURL ::userInfoURL]})
+  {:req-un [::ps/instance ::clientID ::clientSecret ::publicKey ::authorizeURL ::tokenURL ::userProfileURL]})
 
 ;; Defines the contents of the Mi authentication ConfigurationTemplate resource itself.
 (s/def ::session-mitreid

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template_session_oidc.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/configuration_template_session_oidc.cljc
@@ -7,18 +7,17 @@
 
 (s/def ::clientID ::cimi-core/token)
 (s/def ::clientSecret ::cimi-core/token)
-(s/def ::baseURL ::cimi-core/token)
 (s/def ::authorizeURL ::cimi-core/token)
 (s/def ::tokenURL ::cimi-core/token)
 (s/def ::publicKey ::cimi-core/nonblank-string)             ;; allows jwk JSON representation
 
 (def configuration-template-keys-spec-req
-  {:req-un [::ps/instance ::clientID  ::publicKey]
-   :opt-un [::baseURL ::authorizeURL ::tokenURL ::clientSecret]})
+  {:req-un [::ps/instance ::clientID ::publicKey ::authorizeURL ::tokenURL]
+   :opt-un [::clientSecret]})
 
 (def configuration-template-keys-spec-create
-  {:req-un [::ps/instance ::clientID ::publicKey]
-   :opt-un [::baseURL ::authorizeURL ::tokenURL ::clientSecret]})
+  {:req-un [::ps/instance ::clientID ::publicKey ::authorizeURL ::tokenURL]
+   :opt-un [::clientSecret]})
 
 ;; Defines the contents of the OIDC authentication ConfigurationTemplate resource itself.
 (s/def ::session-oidc

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/user_mitreid_registration.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/user_mitreid_registration.clj
@@ -33,13 +33,11 @@
 
 (defmethod p/tpl->user user-template/registration-method
   [{:keys [href redirectURI] :as resource} {:keys [headers base-uri] :as request}]
-  (let [[client-id client-secret base-url public-key authorizeURL tokenURL userInfoURL] (oidc-utils/config-mitreid-params redirectURI (u/document-id href))]
-    (if (or (and base-url client-id public-key) (and authorizeURL tokenURL client-id client-secret public-key))
-      (let [data (when redirectURI {:redirectURI redirectURI})
-            callback-url (user-utils/create-user-mitreid-callback base-uri href data)
-            redirect-url (oidc-utils/create-redirect-url base-url authorizeURL client-id callback-url)]
-        [{:status 303, :headers {"Location" redirect-url}} nil])
-      (oidc-utils/throw-bad-client-config user-template/registration-method redirectURI))))
+  (let [[client-id client-secret public-key authorizeURL tokenURL userInfoURL] (oidc-utils/config-mitreid-params redirectURI (u/document-id href))
+        data (when redirectURI {:redirectURI redirectURI})
+        callback-url (user-utils/create-user-mitreid-callback base-uri href data)
+        redirect-url (oidc-utils/create-redirect-url authorizeURL client-id callback-url)]
+    [{:status 303, :headers {"Location" redirect-url}} nil]))
 
 
 

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/user_mitreid_registration.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/user_mitreid_registration.clj
@@ -33,7 +33,7 @@
 
 (defmethod p/tpl->user user-template/registration-method
   [{:keys [href redirectURI] :as resource} {:keys [headers base-uri] :as request}]
-  (let [[client-id client-secret public-key authorizeURL tokenURL userInfoURL] (oidc-utils/config-mitreid-params redirectURI (u/document-id href))
+  (let [[client-id client-secret public-key authorizeURL tokenURL userProfileURL] (oidc-utils/config-mitreid-params redirectURI (u/document-id href))
         data (when redirectURI {:redirectURI redirectURI})
         callback-url (user-utils/create-user-mitreid-callback base-uri href data)
         redirect-url (oidc-utils/create-redirect-url authorizeURL client-id callback-url)]

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/user_oidc_registration.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/user_oidc_registration.clj
@@ -33,14 +33,12 @@
 
 (defmethod p/tpl->user user-template/registration-method
   [{:keys [href redirectURI] :as resource} {:keys [headers base-uri] :as request}]
-  (let [[client-id client-secret base-url public-key authorizeURL tokenURL] (oidc-utils/config-oidc-params redirectURI (u/document-id href))]
-    (if (or (and base-url client-id public-key) (and authorizeURL tokenURL client-id client-secret public-key))
-      (let [data (when redirectURI {:redirectURI redirectURI})
-            callback-url (user-utils/create-user-oidc-callback base-uri href data)
-            redirect-url (oidc-utils/create-redirect-url base-url authorizeURL client-id callback-url)]
-        [{:status 303, :headers {"Location" redirect-url}} nil])
-      (oidc-utils/throw-bad-client-config user-template/registration-method redirectURI))))
-
+  (let [[client-id client-secret public-key authorizeURL tokenURL]
+        (oidc-utils/config-oidc-params redirectURI (u/document-id href))
+        data (when redirectURI {:redirectURI redirectURI})
+        callback-url (user-utils/create-user-oidc-callback base-uri href data)
+        redirect-url (oidc-utils/create-redirect-url authorizeURL client-id callback-url)]
+        [{:status 303, :headers {"Location" redirect-url}} nil]))
 
 
 ;;

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/configuration_template_lifecycle_test.clj
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/configuration_template_lifecycle_test.clj
@@ -6,8 +6,8 @@
     [com.sixsq.slipstream.ssclj.resources.configuration-template :as ct]
     [com.sixsq.slipstream.ssclj.resources.configuration-template-lifecycle-test-utils :as test-utils]
     [com.sixsq.slipstream.ssclj.resources.configuration-template-session-github :as github]
-    [com.sixsq.slipstream.ssclj.resources.configuration-template-session-oidc :as oidc]
     [com.sixsq.slipstream.ssclj.resources.configuration-template-session-mitreid :as mitreid]
+    [com.sixsq.slipstream.ssclj.resources.configuration-template-session-oidc :as oidc]
     [com.sixsq.slipstream.ssclj.resources.configuration-template-slipstream :as slipstream]
     [com.sixsq.slipstream.ssclj.resources.lifecycle-test-utils :as ltu]
     [peridot.core :refer :all]))

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/configuration_template_lifecycle_test.clj
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/configuration_template_lifecycle_test.clj
@@ -7,6 +7,7 @@
     [com.sixsq.slipstream.ssclj.resources.configuration-template-lifecycle-test-utils :as test-utils]
     [com.sixsq.slipstream.ssclj.resources.configuration-template-session-github :as github]
     [com.sixsq.slipstream.ssclj.resources.configuration-template-session-oidc :as oidc]
+    [com.sixsq.slipstream.ssclj.resources.configuration-template-session-mitreid :as mitreid]
     [com.sixsq.slipstream.ssclj.resources.configuration-template-slipstream :as slipstream]
     [com.sixsq.slipstream.ssclj.resources.lifecycle-test-utils :as ltu]
     [peridot.core :refer :all]))
@@ -19,11 +20,13 @@
 (deftest retrieve-by-id
   (test-utils/check-retrieve-by-id slipstream/service)
   (test-utils/check-retrieve-by-id oidc/service)
+  (test-utils/check-retrieve-by-id mitreid/service)
   (test-utils/check-retrieve-by-id github/service))
 
 (deftest lifecycle
   (test-utils/check-lifecycle slipstream/service)
   (test-utils/check-lifecycle oidc/service)
+  (test-utils/check-lifecycle mitreid/service)
   (test-utils/check-lifecycle github/service))
 
 (deftest bad-methods

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/session_mitreid_lifecycle_test.clj
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/session_mitreid_lifecycle_test.clj
@@ -26,16 +26,15 @@
 
 (def session-template-base-uri (str p/service-context (u/de-camelcase ct/resource-name)))
 
-(def instance-legacy "legacy-test-mitreid")
+
 (def instance "test-mitreid")
 
-(def session-template-mitreid-legacy {:method      mitreid/authn-method
-                                      :instance    instance-legacy
+(def session-template-mitreid {:method      mitreid/authn-method
+                                      :instance    instance
                                       :name        "MITREid Connect"
                                       :description "External Authentication via MITREid Connect Protocol"
                                       :acl         st/resource-acl})
 
-(def session-template-mitreid (assoc session-template-mitreid-legacy :instance instance))
 
 (def ^:const callback-pattern #".*/api/callback/.*/execute")
 
@@ -53,13 +52,6 @@
     "jVunw8YkO7dsBhVP/8bqLDLw/8NsSAKwlzsoNKbrjVQ/NmHMJ88QkiKwv+E6lidy"
     "3wIDAQAB"))
 
-(def configuration-session-mitreid-legacy {:configurationTemplate {:service   "session-mitreid"
-                                                                   :instance  instance-legacy
-                                                                   :clientID  "FAKE_CLIENT_ID"
-                                                                   :baseURL   "https://mitreid.example.com"
-                                                                   :publicKey auth-pubkey}})
-
-
 (def configuration-session-mitreid {:configurationTemplate {:service      "session-mitreid" ;;reusing configuration from session MITREid
                                                             :instance     instance
                                                             :clientID     "FAKE_CLIENT_ID"
@@ -68,6 +60,7 @@
                                                             :tokenURL     "https://token.mitreid.com/token"
                                                             :userInfoURL  "https://userinfo.mitreid.com/api/user/me"
                                                             :publicKey    auth-pubkey}})
+
 
 (deftest lifecycle
 
@@ -136,7 +129,7 @@
           (ltu/is-status 500))
 
 
-      ;; anonymous create must succeed (normal create and href-legacy create)
+      ;; anonymous create must succeed
       (let [
             ;;
             ;; create the session-mitreid configuration to use for these tests
@@ -357,13 +350,12 @@
                 (ltu/is-status 303))                        ;; always expect redirect when redirectURI is provided
 
             ;; add the configurations back again
-            (doseq [conf #{configuration-session-mitreid configuration-session-mitreid-legacy}]
               (-> session-admin
                   (request configuration-base-uri
                            :request-method :post
-                           :body (json/write-str conf))
+                           :body (json/write-str configuration-session-mitreid))
                   (ltu/body->edn)
-                  (ltu/is-status 201)))
+                  (ltu/is-status 201))
 
 
             ;; try hitting the callback without the MITREid code parameter
@@ -392,7 +384,7 @@
                 (ltu/is-status 303))                        ;; always expect redirect when redirectURI is provided
 
             ;; try now with a fake code
-            (with-redefs [auth-oidc/get-access-token (fn [client-id client-secret base-url token-url oauth-code redirect-url]
+            (with-redefs [auth-oidc/get-access-token (fn [client-id client-secret token-url oauth-code redirect-url]
                                                                   (case oauth-code
                                                                     "GOOD" good-token
                                                                     "BAD" bad-token

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/session_mitreid_lifecycle_test.clj
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/session_mitreid_lifecycle_test.clj
@@ -29,11 +29,11 @@
 
 (def instance "test-mitreid")
 
-(def session-template-mitreid {:method      mitreid/authn-method
-                                      :instance    instance
-                                      :name        "MITREid Connect"
-                                      :description "External Authentication via MITREid Connect Protocol"
-                                      :acl         st/resource-acl})
+(def session-template-mitreid {:method       mitreid/authn-method
+                               :instance     instance
+                               :name         "MITREid Connect"
+                               :description  "External Authentication via MITREid Connect Protocol"
+                               :acl          st/resource-acl})
 
 
 (def ^:const callback-pattern #".*/api/callback/.*/execute")
@@ -350,12 +350,12 @@
                 (ltu/is-status 303))                        ;; always expect redirect when redirectURI is provided
 
             ;; add the configurations back again
-              (-> session-admin
-                  (request configuration-base-uri
-                           :request-method :post
-                           :body (json/write-str configuration-session-mitreid))
-                  (ltu/body->edn)
-                  (ltu/is-status 201))
+            (-> session-admin
+                (request configuration-base-uri
+                         :request-method :post
+                         :body (json/write-str configuration-session-mitreid))
+                (ltu/body->edn)
+                (ltu/is-status 201))
 
 
             ;; try hitting the callback without the MITREid code parameter
@@ -385,10 +385,10 @@
 
             ;; try now with a fake code
             (with-redefs [auth-oidc/get-access-token (fn [client-id client-secret token-url oauth-code redirect-url]
-                                                                  (case oauth-code
-                                                                    "GOOD" good-token
-                                                                    "BAD" bad-token
-                                                                    nil))
+                                                       (case oauth-code
+                                                         "GOOD" good-token
+                                                         "BAD" bad-token
+                                                         nil))
                           db/find-roles-for-username (fn [username]
                                                        "USER ANON alpha")
                           db/user-exists? (constantly true)]

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/session_mitreid_lifecycle_test.clj
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/session_mitreid_lifecycle_test.clj
@@ -26,7 +26,7 @@
 
 (def session-template-base-uri (str p/service-context (u/de-camelcase ct/resource-name)))
 
-(def instance "test-MITREid")
+(def instance "test-mitreid")
 
 (def session-template-mitreid {:method       mitreid/authn-method
                                :instance     instance
@@ -51,14 +51,14 @@
     "jVunw8YkO7dsBhVP/8bqLDLw/8NsSAKwlzsoNKbrjVQ/NmHMJ88QkiKwv+E6lidy"
     "3wIDAQAB"))
 
-(def configuration-session-mitreid {:configurationTemplate {:service      "session-mitreid" ;;reusing configuration from session MITREid
-                                                            :instance     instance
-                                                            :clientID     "FAKE_CLIENT_ID"
-                                                            :clientSecret "MyMITREidClientSecret"
-                                                            :authorizeURL "https://authorize.mitreid.com/authorize"
-                                                            :tokenURL     "https://token.mitreid.com/token"
-                                                            :userInfoURL  "https://userinfo.mitreid.com/api/user/me"
-                                                            :publicKey    auth-pubkey}})
+(def configuration-session-mitreid {:configurationTemplate {:service        "session-mitreid" ;;reusing configuration from session MITREid
+                                                            :instance       instance
+                                                            :clientID       "FAKE_CLIENT_ID"
+                                                            :clientSecret   "MyMITREidClientSecret"
+                                                            :authorizeURL   "https://authorize.mitreid.com/authorize"
+                                                            :tokenURL       "https://token.mitreid.com/token"
+                                                            :userProfileURL "https://userinfo.mitreid.com/api/user/me"
+                                                            :publicKey      auth-pubkey}})
 
 
 (deftest lifecycle

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/session_mitreid_lifecycle_test.clj
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/session_mitreid_lifecycle_test.clj
@@ -26,8 +26,7 @@
 
 (def session-template-base-uri (str p/service-context (u/de-camelcase ct/resource-name)))
 
-
-(def instance "test-mitreid")
+(def instance "test-MITREid")
 
 (def session-template-mitreid {:method       mitreid/authn-method
                                :instance     instance
@@ -72,12 +71,10 @@
         session-user (header session-anon authn-info-header "user USER ANON")
         session-anon-form (-> session-anon
                               (content-type u/form-urlencoded))
-
         redirect-uri "https://example.com/webui"]
 
     ;; get session template so that session resources can be tested
-    (let [
-          ;;
+    (let [;;
           ;; create the session template to use for these tests
           ;;
           href (-> session-admin

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/session_oidc_lifecycle_test.clj
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/session_oidc_lifecycle_test.clj
@@ -115,7 +115,6 @@
           (ltu/is-count zero?))
 
       ;; configuration must have OIDC client id and base URL, if not should get 500
-
       (-> session-anon
           (request base-uri
                    :request-method :post
@@ -351,7 +350,6 @@
                 (ltu/is-status 303))                        ;; always expect redirect when redirectURI is provided
 
             ;; add the configurations back again
-
             (-> session-admin
                 (request configuration-base-uri
                          :request-method :post

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/session_oidc_lifecycle_test.clj
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/session_oidc_lifecycle_test.clj
@@ -26,16 +26,14 @@
 
 (def session-template-base-uri (str p/service-context (u/de-camelcase ct/resource-name)))
 
-(def instance-legacy "legacy-test-oidc")
 (def instance "test-oidc")
 
-(def session-template-oidc-legacy {:method      oidc/authn-method
-                                   :instance    instance-legacy
-                                   :name        "OpenID Connect"
-                                   :description "External Authentication via OpenID Connect Protocol"
-                                   :acl         st/resource-acl})
+(def session-template-oidc {:method      oidc/authn-method
+                            :instance    instance
+                            :name        "OpenID Connect"
+                            :description "External Authentication via OpenID Connect Protocol"
+                            :acl         st/resource-acl})
 
-(def session-template-oidc (assoc session-template-oidc-legacy :instance instance))
 
 (def ^:const callback-pattern #".*/api/callback/.*/execute")
 
@@ -53,18 +51,13 @@
     "jVunw8YkO7dsBhVP/8bqLDLw/8NsSAKwlzsoNKbrjVQ/NmHMJ88QkiKwv+E6lidy"
     "3wIDAQAB"))
 
-(def configuration-session-oidc-legacy {:configurationTemplate {:service   "session-oidc"
-                                                                :instance  instance-legacy
-                                                                :clientID  "FAKE_CLIENT_ID"
-                                                                :baseURL   "https://oidc.example.com"
-                                                                :publicKey auth-pubkey}})
-
-(def configuration-session-oidc (-> configuration-session-oidc-legacy
-                                    (update-in [:configurationTemplate] dissoc :baseURL)
-                                    (assoc-in [:configurationTemplate :instance] instance)
-                                    (assoc-in [:configurationTemplate :clientSecret] "MyOIDCClientSecret")
-                                    (assoc-in [:configurationTemplate :authorizeURL] "https://authorize.oidc.com/authorize")
-                                    (assoc-in [:configurationTemplate :tokenURL] "https://token.oidc.com/token")))
+(def configuration-session-oidc {:configurationTemplate {:service      "session-oidc"
+                                                         :instance     instance
+                                                         :clientID     "FAKE_CLIENT_ID"
+                                                         :clientSecret "MyOIDCClientSecret"
+                                                         :authorizeURL "https://authorize.oidc.com/authorize"
+                                                         :tokenURL     "https://token.oidc.com/token"
+                                                         :publicKey    auth-pubkey}})
 
 (deftest lifecycle
 
@@ -84,13 +77,6 @@
           ;;
           ;; create the session template to use for these tests
           ;;
-          href-legacy (-> session-admin
-                          (request session-template-base-uri
-                                   :request-method :post
-                                   :body (json/write-str session-template-oidc-legacy))
-                          (ltu/body->edn)
-                          (ltu/is-status 201)
-                          (ltu/location))
           href (-> session-admin
                    (request session-template-base-uri
                             :request-method :post
@@ -99,13 +85,8 @@
                    (ltu/is-status 201)
                    (ltu/location))
 
-          template-url-legacy (str p/service-context href-legacy)
           template-url (str p/service-context href)
 
-          resp-legacy (-> session-anon
-                          (request template-url-legacy)
-                          (ltu/body->edn)
-                          (ltu/is-status 200))
           resp (-> session-anon
                    (request template-url)
                    (ltu/body->edn)
@@ -117,20 +98,13 @@
           properties-attr {:a "one", :b "two"}
 
           ;;valid-create {:sessionTemplate (ltu/strip-unwanted-attrs template)}
-          href-create-legacy {:name            name-attr
-                              :description     description-attr
-                              :properties      properties-attr
-                              :sessionTemplate {:href href-legacy}}
           href-create {:name            name-attr
                        :description     description-attr
                        :properties      properties-attr
                        :sessionTemplate {:href href}}
 
-          href-create-redirect-legacy {:sessionTemplate {:href        href-legacy
-                                                         :redirectURI redirect-uri}}
           href-create-redirect {:sessionTemplate {:href        href
                                                   :redirectURI redirect-uri}}
-          invalid-create-legacy (assoc-in href-create-legacy [:sessionTemplate :invalid] "BAD")
           invalid-create (assoc-in href-create [:sessionTemplate :invalid] "BAD")]
 
       ;; anonymous query should succeed but have no entries
@@ -141,28 +115,21 @@
           (ltu/is-count zero?))
 
       ;; configuration must have OIDC client id and base URL, if not should get 500
-      (doseq [hcreate #{href-create href-create-legacy}]
+
       (-> session-anon
           (request base-uri
                    :request-method :post
-                   :body (json/write-str hcreate))
+                   :body (json/write-str href-create))
           (ltu/body->edn)
           (ltu/message-matches #".*missing or incorrect configuration.*")
-          (ltu/is-status 500)))
+          (ltu/is-status 500))
 
 
-      ;; anonymous create must succeed (normal create and href-legacy create)
+      ;; anonymous create must succeed
       (let [
             ;;
             ;; create the session-oidc configuration to use for these tests
             ;;
-            cfg-href-legacy (-> session-admin
-                                (request configuration-base-uri
-                                         :request-method :post
-                                         :body (json/write-str configuration-session-oidc-legacy))
-                                (ltu/body->edn)
-                                (ltu/is-status 201)
-                                (ltu/location))
             cfg-href (-> session-admin
                          (request configuration-base-uri
                                   :request-method :post
@@ -182,13 +149,13 @@
             bad-claims {}
             bad-token (sign/sign-claims bad-claims)]
 
-        (is (= cfg-href-legacy (str "configuration/session-oidc-" instance-legacy)))
+
         (is (= cfg-href (str "configuration/session-oidc-" instance)))
 
         (let [resp (-> session-anon
                        (request base-uri
                                 :request-method :post
-                                :body (json/write-str href-create-legacy))
+                                :body (json/write-str href-create))
                        (ltu/body->edn)
                        (ltu/is-status 303))
               id (get-in resp [:response :body :resource-id])
@@ -199,7 +166,7 @@
               resp (-> session-anon
                        (request base-uri
                                 :request-method :post
-                                :body (json/write-str href-create-redirect-legacy))
+                                :body (json/write-str href-create-redirect))
                        (ltu/body->edn)
                        (ltu/is-status 303))
               id2 (get-in resp [:response :body :resource-id])
@@ -210,7 +177,7 @@
               resp (-> session-anon-form
                        (request base-uri
                                 :request-method :post
-                                :body (codec/form-encode {:href        href-legacy
+                                :body (codec/form-encode {:href        href
                                                           :redirectURI redirect-uri}))
                        (ltu/body->edn)
                        (ltu/is-status 303))
@@ -353,12 +320,11 @@
 
 
             ;; remove the authentication configurations
-            (doseq [conf #{cfg-href cfg-href-legacy}]
-              (-> session-admin
-                  (request (str p/service-context conf)
-                           :request-method :delete)
-                  (ltu/body->edn)
-                  (ltu/is-status 200)))
+            (-> session-admin
+                (request (str p/service-context cfg-href)
+                         :request-method :delete)
+                (ltu/body->edn)
+                (ltu/is-status 200))
 
 
             ;; try hitting the callback with an invalid server configuration
@@ -385,13 +351,13 @@
                 (ltu/is-status 303))                        ;; always expect redirect when redirectURI is provided
 
             ;; add the configurations back again
-            (doseq [conf #{configuration-session-oidc configuration-session-oidc-legacy}]
-              (-> session-admin
-                  (request configuration-base-uri
-                           :request-method :post
-                           :body (json/write-str conf))
-                  (ltu/body->edn)
-                  (ltu/is-status 201)))
+
+            (-> session-admin
+                (request configuration-base-uri
+                         :request-method :post
+                         :body (json/write-str configuration-session-oidc))
+                (ltu/body->edn)
+                (ltu/is-status 201))
 
 
             ;; try hitting the callback without the OIDC code parameter
@@ -420,11 +386,11 @@
                 (ltu/is-status 303))                        ;; always expect redirect when redirectURI is provided
 
             ;; try now with a fake code
-            (with-redefs [auth-oidc/get-access-token (fn [client-id client-secret base-url token-url oauth-code redirect-url]
-                                                            (case oauth-code
-                                                              "GOOD" good-token
-                                                              "BAD" bad-token
-                                                              nil))
+            (with-redefs [auth-oidc/get-access-token (fn [client-id client-secret token-url oauth-code redirect-url]
+                                                       (case oauth-code
+                                                         "GOOD" good-token
+                                                         "BAD" bad-token
+                                                         nil))
                           db/find-roles-for-username (fn [username]
                                                        "USER ANON alpha")
                           db/user-exists? (constantly true)]
@@ -538,13 +504,13 @@
               (ltu/is-status 200))
 
           ;; create with invalid template fails
-          (doseq [inv-create #{invalid-create invalid-create-legacy}]
+
           (-> session-anon
               (request base-uri
                        :request-method :post
-                       :body (json/write-str inv-create))
+                       :body (json/write-str invalid-create))
               (ltu/body->edn)
-              (ltu/is-status 400))))))))
+              (ltu/is-status 400)))))))
 
 
 (deftest bad-methods

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/user_mitreid_registration_lifecycle_test.clj
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/user_mitreid_registration_lifecycle_test.clj
@@ -266,7 +266,7 @@
                     bad-claims {}
                     bad-token (sign/sign-claims bad-claims)]
 
-                (with-redefs [auth-oidc/get-access-token (fn [client-id client-secret base-url tokenurl oauth-code redirect-uri]
+                (with-redefs [auth-oidc/get-access-token (fn [client-id client-secret tokenurl oauth-code redirect-uri]
                                                            (case oauth-code
                                                              "GOOD" good-token
                                                              "BAD" bad-token

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/user_mitreid_registration_lifecycle_test.clj
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/user_mitreid_registration_lifecycle_test.clj
@@ -42,14 +42,14 @@
     "jVunw8YkO7dsBhVP/8bqLDLw/8NsSAKwlzsoNKbrjVQ/NmHMJ88QkiKwv+E6lidy"
     "3wIDAQAB"))
 
-(def configuration-user-mitreid {:configurationTemplate {:service      "session-mitreid" ;;reusing configuration from session MITREid
-                                                         :instance     mitreid/registration-method
-                                                         :clientID     "FAKE_CLIENT_ID"
-                                                         :clientSecret "MyMITREidClientSecret"
-                                                         :authorizeURL "https://authorize.mitreid.com/authorize"
-                                                         :tokenURL     "https://token.mitreid.com/token"
-                                                         :userInfoURL  "https://userinfo.mitreid.com/api/user/me"
-                                                         :publicKey    auth-pubkey}})
+(def configuration-user-mitreid {:configurationTemplate {:service        "session-mitreid" ;;reusing configuration from session MITREid
+                                                         :instance       mitreid/registration-method
+                                                         :clientID       "FAKE_CLIENT_ID"
+                                                         :clientSecret   "MyMITREidClientSecret"
+                                                         :authorizeURL   "https://authorize.mitreid.com/authorize"
+                                                         :tokenURL       "https://token.mitreid.com/token"
+                                                         :userProfileURL "https://userinfo.mitreid.com/api/user/me"
+                                                         :publicKey      auth-pubkey}})
 
 (deftest lifecycle
 


### PR DESCRIPTION
OIDC session template configuration should use authorizeURL and tokenURL as mandatory attributes while baseURL is to be removed