### PR TITLE
fix 500 errors from uncaught exceptions

### DIFF
--- a/db-binding/src/com/sixsq/slipstream/db/es/binding.clj
+++ b/db-binding/src/com/sixsq/slipstream/db/es/binding.clj
@@ -98,9 +98,11 @@
   (edit [_ {:keys [id] :as data} options]
     (let [[type docid] (cu/split-id id)
           updated-doc (prepare-data data)]
-      (if (esu/update client (escu/id->index id) type docid updated-doc)
+      (try
+        (esu/update client (escu/id->index id) type docid updated-doc)
         (response/json-response data)
-        (response/response-conflict id))))
+        (catch VersionConflictEngineException _
+          (response/response-conflict id)))))
 
 
   (query [_ collection-id options]


### PR DESCRIPTION
Catch exceptions in database and session processing to produce the correct http status code (not 500). 
