### PR TITLE
Add an optional unit attribute to the storage-bucket resource

### DIFF
--- a/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/storage_bucket.cljc
+++ b/cimi-resources/src/com/sixsq/slipstream/ssclj/resources/spec/storage_bucket.cljc
@@ -8,6 +8,7 @@
 (s/def ::credentials (s/coll-of ::cimi-common/resource-link))
 (s/def ::bucketName ::cimi-core/nonblank-string)
 (s/def ::usage pos-int?)
+(s/def ::unit ::cimi-core/nonblank-string)
 (s/def ::connector ::cimi-common/resource-link)
 (s/def ::serviceOffer ::cimi-common/resource-link)
 (s/def ::externalObject ::cimi-common/resource-link)
@@ -17,7 +18,8 @@
                                     ::connector
                                     ::usage]
                            :opt-un [::externalObject
-                                    ::serviceOffer]})
+                                    ::serviceOffer
+                                    ::unit]})
 
 (def storage-bucket-keys-spec (su/merge-keys-specs [cimi-common/common-attrs
                                                     storage-bucket-specs]))

--- a/cimi-resources/test/com/sixsq/slipstream/ssclj/resources/spec/storage_bucket_test.cljc
+++ b/cimi-resources/test/com/sixsq/slipstream/ssclj/resources/spec/storage_bucket_test.cljc
@@ -35,6 +35,7 @@
                    :properties     {:a "one", :b "two"}
                    :bucketName     "aaa-bbb-111"
                    :usage          123456
+                   :unit           "KB"
                    :connector      {:href "connector/0123-4567-8912"}
                    :credentials    [{:href "credentials/0123-4567-8912"}]
                    :externalObject {:href "external-object/aaa-bbb-ccc", :user {:href "user/test"}}
@@ -63,5 +64,5 @@
     (stu/is-invalid ::bucky/storage-bucket (dissoc bucky-sample k)))
 
   ;; optional keywords
-  (doseq [k #{:externalObject :serviceOffer}]
+  (doseq [k #{:externalObject :serviceOffer :unit}]
     (stu/is-valid ::bucky/storage-bucket (dissoc bucky-sample k))))


### PR DESCRIPTION
Add optional unit in the bucky schema

Connected to https://github.com/SixSq/tasklist/issues/1666