### PR TITLE
Add missing env variable

### DIFF
--- a/metering-rpm/src/scripts/metering
+++ b/metering-rpm/src/scripts/metering
@@ -3,5 +3,6 @@ SLIPSTREAM_RING_CONTAINER_PORT=5001
 ES_HOST=localhost
 ES_PORT=9200
 VM_INDEX=slipstream-virtual-machine
+BUCKY_INDEX=slipstream-storage-bucket
 METERING_INDEX=slipstream-metering
 METERING_PERIOD_MINUTES=1


### PR DESCRIPTION
Although defaulted to `slipstream-storage-bucket` in code , provide explicit variable as part as /etc/default/metering configuration