### PR TITLE
remove common parent attribute for now

### DIFF
--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/common.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/common.cljc
@@ -361,7 +361,7 @@
    :opt-un [::name
             ::description
             ::properties
-            ::parent
+            ;::parent ;; FIXME: fix conflicts elsewhere
             ::resourceMetadata
             ::operations]})
 
@@ -377,7 +377,7 @@
             ::created
             ::updated
             ::properties
-            ::parent
+            ;::parent ;; FIXME: fix conflicts elsewhere
             ::resourceMetadata
             ::operations
             ::acl]})
@@ -394,7 +394,7 @@
             ::created
             ::updated
             ::properties
-            ::parent
+            ;::parent ;; FIXME: fix conflicts elsewhere
             ::resourceMetadata
             ::operations
             ::acl]})


### PR DESCRIPTION
Common parent attribute conflicts with attribute with same name in module/deployment resources.