### PR TITLE
update email schema

### DIFF
--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_email_validation.clj
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/callback_email_validation.clj
@@ -20,7 +20,7 @@
   (try
     (-> (crud/retrieve-by-id-as-admin email-id)
         (u/update-timestamps)
-        (assoc :validated? true)
+        (assoc :validated true)
         (db/edit admin-opts))
     (catch Exception e
       (or (ex-data e) (throw e)))))
@@ -28,8 +28,8 @@
 
 (defmethod callback/execute action-name
   [{{:keys [href]} :targetResource :as callback-resource} request]
-  (let [{:keys [id validated?] :as email} (crud/retrieve-by-id-as-admin href)]
-    (if-not validated?
+  (let [{:keys [id validated] :as email} (crud/retrieve-by-id-as-admin href)]
+    (if-not validated
       (let [msg (str id " successfully validated")]
         (validated-email! id)
         (log/info msg)

--- a/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/email.cljc
+++ b/cimi/src/com/sixsq/slipstream/ssclj/resources/spec/email.cljc
@@ -3,14 +3,56 @@
     [clojure.spec.alpha :as s]
     [com.sixsq.slipstream.ssclj.resources.spec.common :as c]
     [com.sixsq.slipstream.ssclj.resources.spec.core :as cimi-core]
-    [com.sixsq.slipstream.ssclj.util.spec :as su]))
+    [com.sixsq.slipstream.ssclj.util.spec :as su]
+    [spec-tools.core :as st]
+    [com.sixsq.slipstream.ssclj.resources.spec.common-namespaces :as common-ns]))
 
 
-(s/def ::address ::cimi-core/email)
-(s/def ::validated? boolean?)
+(s/def ::address
+  (-> (st/spec ::cimi-core/email)
+      (assoc :name "address"
+             :type :string
+             :json-schema/name "address"
+             :json-schema/namespace common-ns/slipstream-namespace
+             :json-schema/uri common-ns/slipstream-uri
+             :json-schema/type "string"
+             :json-schema/providerMandatory true
+             :json-schema/consumerMandatory true
+             :json-schema/mutable true
+             :json-schema/consumerWritable true
+
+             :json-schema/displayName "address"
+             :json-schema/description "email address"
+             :json-schema/help "unique email address"
+             :json-schema/group "body"
+             :json-schema/order 10
+             :json-schema/hidden false
+             :json-schema/sensitive false)))
+
+
+(s/def ::validated
+  (-> (st/spec boolean?)
+      (assoc :name "validated"
+             :type :string
+             :json-schema/name "validated"
+             :json-schema/namespace common-ns/slipstream-namespace
+             :json-schema/uri common-ns/slipstream-uri
+             :json-schema/type "string"
+             :json-schema/providerMandatory true
+             :json-schema/consumerMandatory false
+             :json-schema/mutable true
+             :json-schema/consumerWritable false
+
+             :json-schema/displayName "validated"
+             :json-schema/description "validated email address?"
+             :json-schema/help "flag indicating if the associated email address has been validated"
+             :json-schema/group "body"
+             :json-schema/order 11
+             :json-schema/hidden false
+             :json-schema/sensitive false)))
 
 
 (s/def ::email
   (su/only-keys-maps c/common-attrs
-                     {:req-un [::address
-                               ::validated?]}))
+                     {:req-un [::address]
+                      :opt-un [::validated]}))

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/email_lifecycle_test.clj
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/email_lifecycle_test.clj
@@ -76,8 +76,8 @@
     (let [admin-uri (-> session-admin
                         (request base-uri
                                  :request-method :post
-                                 :body (json/write-str {:address    "admin@example.com"
-                                                        :validated? true}))
+                                 :body (json/write-str {:address   "admin@example.com"
+                                                        :validated true}))
                         (ltu/body->edn)
                         (ltu/is-status 201)
                         (ltu/location))
@@ -86,8 +86,8 @@
           user-uri (-> session-user
                        (request base-uri
                                 :request-method :post
-                                :body (json/write-str {:address    "user@example.com"
-                                                       :validated? true}))
+                                :body (json/write-str {:address   "user@example.com"
+                                                       :validated true}))
                        (ltu/body->edn)
                        (ltu/is-status 201)
                        (ltu/location))
@@ -122,7 +122,7 @@
             validate-url (->> (u/get-op email "validate")
                               (str p/service-context))]
         (is (= "admin@example.com" (:address email)))
-        (is (false? (:validated? email)))
+        (is (false? (:validated email)))
         (is validate-url)
 
         (let [validation-link (atom nil)]
@@ -163,7 +163,7 @@
                              (ltu/is-operation-absent (:validate c/action-uri))
                              :response
                              :body
-                             :validated?)))))))
+                             :validated)))))))
 
       ;; verify contents of user email
       (let [email (-> session-user
@@ -178,14 +178,8 @@
             validate-url (->> (u/get-op email "validate")
                               (str p/service-context))]
         (is (= "user@example.com" (:address email)))
-        (is (false? (:validated? email)))
-        (is validate-url)
-
-        #_(-> session-anon
-              (request validate-url)
-              (ltu/body->edn)
-              (ltu/is-status 200)))
-
+        (is (false? (:validated email)))
+        (is validate-url))
 
       ;; admin can delete the email
       (-> session-admin

--- a/cimi/test/com/sixsq/slipstream/ssclj/resources/spec/email_test.cljc
+++ b/cimi/test/com/sixsq/slipstream/ssclj/resources/spec/email_test.cljc
@@ -21,11 +21,14 @@
                :updated     timestamp
                :acl         valid-acl
                :address     "user@example.com"
-               :validated?  false}]
+               :validated   false}]
 
     (stu/is-valid ::email/email email)
 
     (stu/is-invalid ::email/email (assoc email :bad "value"))
 
-    (doseq [attr #{:id :resourceURI :created :updated :acl :address :validated?}]
-      (stu/is-invalid ::email/email (dissoc email attr)))))
+    (doseq [attr #{:id :resourceURI :created :updated :acl :address}]
+      (stu/is-invalid ::email/email (dissoc email attr)))
+
+    (doseq [attr #{:validated}]
+      (stu/is-valid ::email/email (dissoc email attr)))))


### PR DESCRIPTION
Fix the email schema by renaming `validated?` to `validated` and by making it optional for the clients.

Connected to #1683. 